### PR TITLE
Make stylisation generic over output formats

### DIFF
--- a/src/formaters/html.rs
+++ b/src/formaters/html.rs
@@ -21,6 +21,15 @@ impl Formatter for HtmlFormatter {
         input.push_str(&dup);
         input.push_str("</a>");
     }
+
+    fn verbatim(&self, input: &mut String) {
+        input.insert_str(0, "<pre>");
+        input.push_str("</pre>");
+    }
+
+    fn escape(&self, _input: &mut String) {
+        todo!()
+    }
 }
 
 #[cfg(test)]

--- a/src/formaters/html.rs
+++ b/src/formaters/html.rs
@@ -1,0 +1,62 @@
+use super::Formatter;
+
+pub struct HtmlFormatter;
+
+impl Formatter for HtmlFormatter {
+    fn italics(input: &mut String) {
+        input.insert_str(0, "<i>");
+        input.push_str("</i>");
+    }
+
+    fn bold(input: &mut String) {
+        input.insert_str(0, "<b>");
+        input.push_str("</b>");
+    }
+
+    fn hyperlink(input: &mut String) {
+        let dup = input.clone();
+        input.insert_str(0, "<a href=\"");
+        input.push_str("\">");
+        input.push_str(&dup);
+        input.push_str("</a>");
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::formaters::html::HtmlFormatter;
+    use crate::formaters::Formatter;
+
+    #[test]
+    fn bold() {
+        let mut s = String::from("asdf  hey! this is _some_ weird__ input::!");
+
+        HtmlFormatter::bold(&mut s);
+        assert_eq!(
+            s,
+            String::from("<b>asdf  hey! this is _some_ weird__ input::!</b>")
+        );
+    }
+
+    #[test]
+    fn italics() {
+        let mut s = String::from("asdf  hey! this is _some_ weird__ input::!");
+
+        HtmlFormatter::italics(&mut s);
+        assert_eq!(
+            s,
+            String::from("<i>asdf  hey! this is _some_ weird__ input::!</i>")
+        );
+    }
+
+    #[test]
+    fn hyperlink() {
+        let mut s = String::from("https://example.com");
+
+        HtmlFormatter::hyperlink(&mut s);
+        assert_eq!(
+            s,
+            String::from("<a href=\"https://example.com\">https://example.com</a>")
+        );
+    }
+}

--- a/src/formaters/html.rs
+++ b/src/formaters/html.rs
@@ -1,19 +1,20 @@
 use super::Formatter;
 
+#[derive(Default)]
 pub struct HtmlFormatter;
 
 impl Formatter for HtmlFormatter {
-    fn italics(input: &mut String) {
+    fn italics(&self, input: &mut String) {
         input.insert_str(0, "<i>");
         input.push_str("</i>");
     }
 
-    fn bold(input: &mut String) {
+    fn bold(&self, input: &mut String) {
         input.insert_str(0, "<b>");
         input.push_str("</b>");
     }
 
-    fn hyperlink(input: &mut String) {
+    fn hyperlink(&self, input: &mut String) {
         let dup = input.clone();
         input.insert_str(0, "<a href=\"");
         input.push_str("\">");
@@ -31,7 +32,7 @@ mod test {
     fn bold() {
         let mut s = String::from("asdf  hey! this is _some_ weird__ input::!");
 
-        HtmlFormatter::bold(&mut s);
+        HtmlFormatter.bold(&mut s);
         assert_eq!(
             s,
             String::from("<b>asdf  hey! this is _some_ weird__ input::!</b>")
@@ -42,7 +43,7 @@ mod test {
     fn italics() {
         let mut s = String::from("asdf  hey! this is _some_ weird__ input::!");
 
-        HtmlFormatter::italics(&mut s);
+        HtmlFormatter.italics(&mut s);
         assert_eq!(
             s,
             String::from("<i>asdf  hey! this is _some_ weird__ input::!</i>")
@@ -53,7 +54,7 @@ mod test {
     fn hyperlink() {
         let mut s = String::from("https://example.com");
 
-        HtmlFormatter::hyperlink(&mut s);
+        HtmlFormatter.hyperlink(&mut s);
         assert_eq!(
             s,
             String::from("<a href=\"https://example.com\">https://example.com</a>")

--- a/src/formaters/markdown.rs
+++ b/src/formaters/markdown.rs
@@ -1,0 +1,62 @@
+use super::Formatter;
+
+pub struct MarkdownFormatter;
+
+impl Formatter for MarkdownFormatter {
+    fn italics(input: &mut String) {
+        input.insert(0, '*');
+        input.push('*');
+    }
+
+    fn bold(input: &mut String) {
+        input.insert_str(0, "**");
+        input.push_str("**");
+    }
+
+    fn hyperlink(input: &mut String) {
+        let dup = input.clone();
+        input.insert(0, '[');
+        input.push_str("](");
+        input.push_str(&dup);
+        input.push(')');
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::formaters::markdown::MarkdownFormatter;
+    use crate::formaters::Formatter;
+
+    #[test]
+    fn bold() {
+        let mut s = String::from("asdf  hey! this is _some_ weird__ input::!");
+
+        MarkdownFormatter::bold(&mut s);
+        assert_eq!(
+            s,
+            String::from("**asdf  hey! this is _some_ weird__ input::!**")
+        );
+    }
+
+    #[test]
+    fn italics() {
+        let mut s = String::from("asdf  hey! this is _some_ weird__ input::!");
+
+        MarkdownFormatter::italics(&mut s);
+        assert_eq!(
+            s,
+            String::from("*asdf  hey! this is _some_ weird__ input::!*")
+        );
+    }
+
+    #[test]
+    fn hyperlink() {
+        let mut s = String::from("https://example.com");
+
+        MarkdownFormatter::hyperlink(&mut s);
+        assert_eq!(
+            s,
+            String::from("[https://example.com](https://example.com)")
+        );
+    }
+}

--- a/src/formaters/markdown.rs
+++ b/src/formaters/markdown.rs
@@ -21,6 +21,15 @@ impl Formatter for MarkdownFormatter {
         input.push_str(&dup);
         input.push(')');
     }
+
+    fn verbatim(&self, input: &mut String) {
+        input.insert(0, '`');
+        input.push('`');
+    }
+
+    fn escape(&self, _input: &mut String) {
+        todo!()
+    }
 }
 
 #[cfg(test)]

--- a/src/formaters/markdown.rs
+++ b/src/formaters/markdown.rs
@@ -1,19 +1,20 @@
 use super::Formatter;
 
+#[derive(Default)]
 pub struct MarkdownFormatter;
 
 impl Formatter for MarkdownFormatter {
-    fn italics(input: &mut String) {
+    fn italics(&self, input: &mut String) {
         input.insert(0, '*');
         input.push('*');
     }
 
-    fn bold(input: &mut String) {
+    fn bold(&self, input: &mut String) {
         input.insert_str(0, "**");
         input.push_str("**");
     }
 
-    fn hyperlink(input: &mut String) {
+    fn hyperlink(&self, input: &mut String) {
         let dup = input.clone();
         input.insert(0, '[');
         input.push_str("](");
@@ -31,7 +32,7 @@ mod test {
     fn bold() {
         let mut s = String::from("asdf  hey! this is _some_ weird__ input::!");
 
-        MarkdownFormatter::bold(&mut s);
+        MarkdownFormatter.bold(&mut s);
         assert_eq!(
             s,
             String::from("**asdf  hey! this is _some_ weird__ input::!**")
@@ -42,7 +43,7 @@ mod test {
     fn italics() {
         let mut s = String::from("asdf  hey! this is _some_ weird__ input::!");
 
-        MarkdownFormatter::italics(&mut s);
+        MarkdownFormatter.italics(&mut s);
         assert_eq!(
             s,
             String::from("*asdf  hey! this is _some_ weird__ input::!*")
@@ -53,7 +54,7 @@ mod test {
     fn hyperlink() {
         let mut s = String::from("https://example.com");
 
-        MarkdownFormatter::hyperlink(&mut s);
+        MarkdownFormatter.hyperlink(&mut s);
         assert_eq!(
             s,
             String::from("[https://example.com](https://example.com)")

--- a/src/formaters/mod.rs
+++ b/src/formaters/mod.rs
@@ -5,7 +5,7 @@ pub mod plain;
 // Some rudimentary benchmarking has shown that mutating inplace is the fastest
 // for benchmarks see https://github.com/savente93/str_manip_bench
 pub trait Formatter {
-    fn italics(input: &mut String);
-    fn bold(input: &mut String);
-    fn hyperlink(input: &mut String);
+    fn italics(&self, input: &mut String);
+    fn bold(&self, input: &mut String);
+    fn hyperlink(&self, input: &mut String);
 }

--- a/src/formaters/mod.rs
+++ b/src/formaters/mod.rs
@@ -8,4 +8,6 @@ pub trait Formatter {
     fn italics(&self, input: &mut String);
     fn bold(&self, input: &mut String);
     fn hyperlink(&self, input: &mut String);
+    fn verbatim(&self, input: &mut String);
+    fn escape(&self, input: &mut String);
 }

--- a/src/formaters/mod.rs
+++ b/src/formaters/mod.rs
@@ -1,0 +1,11 @@
+pub mod html;
+pub mod markdown;
+pub mod plain;
+
+// Some rudimentary benchmarking has shown that mutating inplace is the fastest
+// for benchmarks see https://github.com/savente93/str_manip_bench
+pub trait Formatter {
+    fn italics(input: &mut String);
+    fn bold(input: &mut String);
+    fn hyperlink(input: &mut String);
+}

--- a/src/formaters/plain.rs
+++ b/src/formaters/plain.rs
@@ -1,0 +1,50 @@
+use super::Formatter;
+
+pub struct PlainTextFormatter;
+
+impl Formatter for PlainTextFormatter {
+    fn italics(_input: &mut String) {}
+
+    fn bold(_input: &mut String) {}
+
+    fn hyperlink(_input: &mut String) {}
+}
+
+#[cfg(test)]
+mod test {
+    use crate::formaters::plain::PlainTextFormatter;
+    use crate::formaters::Formatter;
+
+    #[test]
+    fn bold() {
+        let mut s = String::from("asdf  hey! this is _some_ weird__ input::!");
+
+        PlainTextFormatter::bold(&mut s);
+        assert_eq!(
+            s,
+            String::from("asdf  hey! this is _some_ weird__ input::!")
+        );
+    }
+
+    #[test]
+    fn italics() {
+        let mut s = String::from("asdf  hey! this is _some_ weird__ input::!");
+
+        PlainTextFormatter::italics(&mut s);
+        assert_eq!(
+            s,
+            String::from("asdf  hey! this is _some_ weird__ input::!")
+        );
+    }
+
+    #[test]
+    fn hyperlink() {
+        let mut s = String::from("asdf  hey! this is _some_ weird__ input::!");
+
+        PlainTextFormatter::hyperlink(&mut s);
+        assert_eq!(
+            s,
+            String::from("asdf  hey! this is _some_ weird__ input::!")
+        );
+    }
+}

--- a/src/formaters/plain.rs
+++ b/src/formaters/plain.rs
@@ -9,6 +9,10 @@ impl Formatter for PlainTextFormatter {
     fn bold(&self, _input: &mut String) {}
 
     fn hyperlink(&self, _input: &mut String) {}
+
+    fn verbatim(&self, _input: &mut String) {}
+
+    fn escape(&self, _input: &mut String) {}
 }
 
 #[cfg(test)]

--- a/src/formaters/plain.rs
+++ b/src/formaters/plain.rs
@@ -1,13 +1,14 @@
 use super::Formatter;
 
+#[derive(Default)]
 pub struct PlainTextFormatter;
 
 impl Formatter for PlainTextFormatter {
-    fn italics(_input: &mut String) {}
+    fn italics(&self, _input: &mut String) {}
 
-    fn bold(_input: &mut String) {}
+    fn bold(&self, _input: &mut String) {}
 
-    fn hyperlink(_input: &mut String) {}
+    fn hyperlink(&self, _input: &mut String) {}
 }
 
 #[cfg(test)]
@@ -19,7 +20,7 @@ mod test {
     fn bold() {
         let mut s = String::from("asdf  hey! this is _some_ weird__ input::!");
 
-        PlainTextFormatter::bold(&mut s);
+        PlainTextFormatter.bold(&mut s);
         assert_eq!(
             s,
             String::from("asdf  hey! this is _some_ weird__ input::!")
@@ -30,7 +31,7 @@ mod test {
     fn italics() {
         let mut s = String::from("asdf  hey! this is _some_ weird__ input::!");
 
-        PlainTextFormatter::italics(&mut s);
+        PlainTextFormatter.italics(&mut s);
         assert_eq!(
             s,
             String::from("asdf  hey! this is _some_ weird__ input::!")
@@ -41,7 +42,7 @@ mod test {
     fn hyperlink() {
         let mut s = String::from("asdf  hey! this is _some_ weird__ input::!");
 
-        PlainTextFormatter::hyperlink(&mut s);
+        PlainTextFormatter.hyperlink(&mut s);
         assert_eq!(
             s,
             String::from("asdf  hey! this is _some_ weird__ input::!")

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,14 @@ mod parsing;
 pub mod styles;
 pub mod utils;
 
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
+pub enum Format {
+    #[default]
+    Plain,
+    Markdown,
+    Html,
+}
+
 #[derive(Parser)]
 #[command(
     name = "file_reader",
@@ -25,6 +33,10 @@ struct Args {
     /// the reference style in which to print the references
     #[arg(short, long, value_enum, default_value_t = ReferenceStyle::IEEE)]
     style: ReferenceStyle,
+
+    /// the format in which to print the references
+    #[arg(short, long, value_enum, default_value_t = Format::Plain)]
+    format: Format,
 
     /// the keys of the references to print. If none are provided all references will be printed
     keys: Vec<String>,
@@ -43,7 +55,6 @@ struct Args {
 fn main() -> Result<()> {
     colog::init();
     let args = Args::parse();
-
     let mut bibliography = Bibliography::new();
 
     for p in args.bib_files.clone() {
@@ -52,17 +63,17 @@ fn main() -> Result<()> {
     }
 
     if let Some(inplace_path) = args.inplace_file {
-        bibliography.expand_file_citations_inplace(inplace_path, args.style)?;
+        bibliography.expand_file_citations_inplace(inplace_path, args.style, args.format)?;
         Ok(())
     } else if args.keys.is_empty() {
         bibliography
-            .fmt_entries(args.style)
+            .fmt_entries(args.style, args.format)
             .into_iter()
             .for_each(|f| println!("{}", f));
         Ok(())
     } else {
         let (formatted, unknown_keys) =
-            bibliography.fmt_entries_filtered(args.style, args.keys.clone());
+            bibliography.fmt_entries_filtered(args.style, args.format, args.keys.clone());
         if formatted.is_empty() && !args.quiet {
             Err(anyhow!(
                 "none of the keys {:?} found in bib file(s) {:?}",

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ use log::warn;
 use std::path::PathBuf;
 use styles::ReferenceStyle;
 
+pub mod formaters;
 mod parsing;
 pub mod styles;
 pub mod utils;

--- a/src/parsing/bibligraphy.rs
+++ b/src/parsing/bibligraphy.rs
@@ -7,7 +7,7 @@ use std::{
 
 use nom::{combinator::all_consuming, multi::many1};
 
-use crate::styles::ReferenceStyle;
+use crate::{styles::ReferenceStyle, Format};
 
 use super::entry::{all_citations, entry, BibEntry, EntrySubComponents};
 
@@ -20,10 +20,10 @@ impl Bibliography {
         self.entries.iter().find(|&e| e.key == key).cloned()
     }
 
-    pub fn fmt_entries(self, style: ReferenceStyle) -> Vec<String> {
+    pub fn fmt_entries(self, style: ReferenceStyle, format: Format) -> Vec<String> {
         self.entries
             .into_iter()
-            .map(|b| style.fmt_reference(b))
+            .map(|b| style.fmt_reference(b, format))
             .collect()
     }
     pub fn has_key(&self, key: &String) -> bool {
@@ -32,13 +32,14 @@ impl Bibliography {
     pub fn fmt_entries_filtered(
         self,
         style: ReferenceStyle,
+        format: Format,
         keys: Vec<String>,
     ) -> (Vec<String>, Vec<String>) {
         let (known_keys, unknown_keys): (Vec<String>, Vec<String>) =
             keys.into_iter().partition(|e| self.has_key(e));
         let formatted: Vec<String> = known_keys
             .into_iter()
-            .map(|b| style.fmt_reference(self.get_entry(b).unwrap()))
+            .map(|b| style.fmt_reference(self.get_entry(b).unwrap(), format))
             .collect();
         (formatted, unknown_keys)
     }
@@ -47,15 +48,25 @@ impl Bibliography {
         Self { entries: vec![] }
     }
 
-    pub fn expand_file_citations_inplace(self, path: PathBuf, style: ReferenceStyle) -> Result<()> {
+    pub fn expand_file_citations_inplace(
+        self,
+        path: PathBuf,
+        style: ReferenceStyle,
+        format: Format,
+    ) -> Result<()> {
         let mut contents = read_to_string(&path)?;
-        contents = self.expand_citations_in_string(contents, style);
+        contents = self.expand_citations_in_string(contents, style, format);
         let mut file = File::create(&path)?;
         file.write_all(contents.as_bytes()).unwrap();
         Ok(())
     }
 
-    pub fn expand_citations_in_string(self, contents: String, style: ReferenceStyle) -> String {
+    pub fn expand_citations_in_string(
+        self,
+        contents: String,
+        style: ReferenceStyle,
+        format: Format,
+    ) -> String {
         let (tail, segments) = all_citations(&contents).unwrap();
         let mut acc =
             segments
@@ -63,7 +74,10 @@ impl Bibliography {
                 .fold(String::new(), |mut acc, (unmodified, citation_key)| {
                     acc.push_str(unmodified);
                     acc.push_str(
-                        &style.fmt_reference(self.get_entry(citation_key.to_string()).unwrap()),
+                        &style.fmt_reference(
+                            self.get_entry(citation_key.to_string()).unwrap(),
+                            format,
+                        ),
                     );
                     acc
                 });

--- a/src/styles/apa.rs
+++ b/src/styles/apa.rs
@@ -468,7 +468,6 @@ mod test {
     use std::path::PathBuf;
 
     use crate::parsing::bibligraphy::Bibliography;
-    use crate::ReferenceStyle;
 
     use super::*;
     use anyhow::Result;

--- a/src/styles/apa.rs
+++ b/src/styles/apa.rs
@@ -93,7 +93,8 @@ impl<T: Formatter> Stylizer for ApaStylizer<T> {
         fields: BTreeMap<String, String>,
     ) -> String {
         let mut out = String::new();
-        let title = fields.get("title").unwrap();
+        let mut title = fields.get("title").unwrap().clone();
+        self.fmt.italics(&mut title);
         let year = fields.get("year");
         let month = fields.get("month");
         let school = fields.get("school").unwrap();
@@ -102,7 +103,7 @@ impl<T: Formatter> Stylizer for ApaStylizer<T> {
         out.push('(');
         out.push_str(&Self::fmt_year_month(self, year, month));
         out.push_str("). ");
-        out.push_str(title);
+        out.push_str(&title);
         out.push(' ');
         match kind {
             ThesisKind::Phd => out.push_str(&format!("[Doctoral dissertation, {}].", school)),
@@ -132,7 +133,8 @@ impl<T: Formatter> Stylizer for ApaStylizer<T> {
 
     fn fmt_manual(&self, authors: Vec<OwnedFullName>, fields: BTreeMap<String, String>) -> String {
         let mut out = String::new();
-        let title = fields.get("title").unwrap();
+        let mut title = fields.get("title").unwrap().clone();
+        self.fmt.italics(&mut title);
         let year = fields.get("year");
         let month = fields.get("month");
         let organization = fields.get("organization").unwrap();
@@ -142,7 +144,7 @@ impl<T: Formatter> Stylizer for ApaStylizer<T> {
         out.push('(');
         out.push_str(&Self::fmt_year_month(self, year, month));
         out.push_str("). ");
-        out.push_str(title);
+        out.push_str(&title);
         out.push_str(". ");
         out.push_str(&format!("{}. ", organization));
         out.push_str(&format!("{}.", address));
@@ -159,7 +161,8 @@ impl<T: Formatter> Stylizer for ApaStylizer<T> {
         let title = fields.get("title").unwrap();
         let year = fields.get("year");
         let month = fields.get("month");
-        let booktitle = fields.get("booktitle").unwrap();
+        let mut booktitle = fields.get("booktitle").unwrap().clone();
+        self.fmt.italics(&mut booktitle);
         let pages = fields.get("pages").unwrap();
         out.push_str(&Self::fmt_authors(self, authors));
         out.push(' ');
@@ -168,7 +171,7 @@ impl<T: Formatter> Stylizer for ApaStylizer<T> {
         out.push_str("). ");
         out.push_str(title);
         out.push_str(". ");
-        out.push_str(booktitle);
+        out.push_str(&booktitle);
         out.push_str(", ");
         out.push_str(pages);
         out.push('.');
@@ -185,7 +188,8 @@ impl<T: Formatter> Stylizer for ApaStylizer<T> {
         let title = fields.get("title").unwrap();
         let year = fields.get("year");
         let month = fields.get("month");
-        let booktitle = fields.get("booktitle").unwrap();
+        let mut booktitle = fields.get("booktitle").unwrap().clone();
+        self.fmt.italics(&mut booktitle);
         let pages = fields.get("pages").unwrap();
         let editors_str = fields.get("editor").unwrap();
         let (_tail, edrs) = and_seperated_names(editors_str).unwrap();
@@ -200,7 +204,7 @@ impl<T: Formatter> Stylizer for ApaStylizer<T> {
         out.push_str(". In ");
         out.push_str(&fmt_editors(editor_names));
         out.push_str(" (Eds.), ");
-        out.push_str(booktitle);
+        out.push_str(&booktitle);
         out.push_str(&format!(" (pp. {}). ", pages));
         out.push_str(publisher);
         out.push('.');
@@ -213,7 +217,8 @@ impl<T: Formatter> Stylizer for ApaStylizer<T> {
         let title = fields.get("title").unwrap();
         let year = fields.get("year");
         let month = fields.get("month");
-        let booktitle = fields.get("booktitle").unwrap();
+        let mut booktitle = fields.get("booktitle").unwrap().clone();
+        self.fmt.italics(&mut booktitle);
         let publisher = fields.get("publisher").unwrap();
         let pages = fields.get("pages").unwrap();
         out.push_str(&Self::fmt_authors(self, authors));
@@ -223,7 +228,7 @@ impl<T: Formatter> Stylizer for ApaStylizer<T> {
         out.push_str("). ");
         out.push_str(title);
         out.push_str(". In ");
-        out.push_str(booktitle);
+        out.push_str(&booktitle);
         out.push_str(&format!(" (pp. {}). ", pages));
         out.push_str(publisher);
         out.push('.');
@@ -239,7 +244,8 @@ impl<T: Formatter> Stylizer for ApaStylizer<T> {
         let mut out = String::new();
         let publisher = fields.get("publisher").unwrap();
         let year = fields.get("year").unwrap();
-        let booktitle = fields.get("booktitle").unwrap();
+        let mut booktitle = fields.get("booktitle").unwrap().clone();
+        self.fmt.italics(&mut booktitle);
         let pages = fields.get("pages").unwrap();
         let title = fields.get("title").unwrap();
         let editors_str = fields.get("editor").unwrap();
@@ -251,7 +257,7 @@ impl<T: Formatter> Stylizer for ApaStylizer<T> {
         out.push_str(&format!("{} ", &title));
         out.push_str(&format!("[Review of {}]. ", &title));
         out.push_str(&format!("In {} (Ed.), ", &fmt_editors(editor_names)));
-        out.push_str(&(&booktitle).to_string());
+        out.push_str(&booktitle);
         out.push_str(&format!(" (pp. {}).", &pages));
         out.push_str(&format!(" {}.", &publisher));
 
@@ -260,14 +266,15 @@ impl<T: Formatter> Stylizer for ApaStylizer<T> {
 
     fn fmt_booklet(&self, authors: Vec<OwnedFullName>, fields: BTreeMap<String, String>) -> String {
         let mut out = String::new();
-        let title = fields.get("title").unwrap();
+        let mut title = fields.get("title").unwrap().clone();
+        self.fmt.italics(&mut title);
         let year = fields.get("year");
         let month = fields.get("month");
         let howpublished = fields.get("howpublished").unwrap();
 
         out.push_str(&Self::fmt_authors(self, authors));
         out.push(' ');
-        out.push_str(title);
+        out.push_str(&title);
         out.push_str(". ");
         out.push_str(howpublished);
         out.push_str(". ");
@@ -279,7 +286,8 @@ impl<T: Formatter> Stylizer for ApaStylizer<T> {
 
     fn fmt_book(&self, authors: Vec<OwnedFullName>, fields: BTreeMap<String, String>) -> String {
         let mut out = String::new();
-        let title = fields.get("title").unwrap();
+        let mut title = fields.get("title").unwrap().clone();
+        self.fmt.italics(&mut title);
         let year = fields.get("year");
         let month = fields.get("month");
         let publisher = fields.get("publisher").unwrap();
@@ -288,7 +296,7 @@ impl<T: Formatter> Stylizer for ApaStylizer<T> {
         out.push('(');
         out.push_str(&Self::fmt_year_month(self, year, month));
         out.push_str("). ");
-        out.push_str(title);
+        out.push_str(&title);
         out.push_str(". ");
         out.push_str(publisher);
         out.push('.');

--- a/src/styles/apa.rs
+++ b/src/styles/apa.rs
@@ -1,381 +1,402 @@
 use std::collections::BTreeMap;
 
-use crate::parsing::{
-    entry::BibEntry,
-    names::{and_seperated_names, OwnedFullName},
-};
+use crate::parsing::names::{and_seperated_names, OwnedFullName};
 use chrono::NaiveDate;
 use unicode_segmentation::UnicodeSegmentation;
 
-use super::ThesisKind;
+use super::{Stylizer, ThesisKind};
 
-pub fn fmt_reference_apa(entry: BibEntry) -> String {
-    let (kind, _key, authors, fields) = entry.into_components();
+pub struct ApaStylizer;
 
-    match kind {
-        crate::parsing::entry::EntryType::Article => fmt_article_apa(authors, fields),
-        crate::parsing::entry::EntryType::Book => fmt_book_apa(authors, fields),
-        crate::parsing::entry::EntryType::Booklet => fmt_booklet_apa(authors, fields),
-        crate::parsing::entry::EntryType::Conference => fmt_conference_apa(authors, fields),
-        crate::parsing::entry::EntryType::Inbook => fmt_inbook_apa(authors, fields),
-        crate::parsing::entry::EntryType::Incollection => fmt_incollection_apa(authors, fields),
-        crate::parsing::entry::EntryType::Inproceedings => fmt_inproceedings_apa(authors, fields),
-        crate::parsing::entry::EntryType::Manual => fmt_manual_apa(authors, fields),
-        crate::parsing::entry::EntryType::Mastersthesis => {
-            fmt_thesis_apa(ThesisKind::Msc, authors, fields)
-        }
-        crate::parsing::entry::EntryType::Misc => fmt_misc_apa(authors, fields),
-        crate::parsing::entry::EntryType::Phdthesis => {
-            fmt_thesis_apa(ThesisKind::Phd, authors, fields)
-        }
-        crate::parsing::entry::EntryType::Proceedings => fmt_proceedings_apa(fields),
-        crate::parsing::entry::EntryType::Techreport => fmt_techreport_apa(authors, fields),
-        crate::parsing::entry::EntryType::Unpublished => fmt_unpublished_apa(authors, fields),
-    }
-}
-
-fn fmt_unpublished_apa(authors: Vec<OwnedFullName>, fields: BTreeMap<String, String>) -> String {
-    let mut out = String::new();
-    let title = fields.get("title").unwrap();
-    let year = fields.get("year");
-    let month = fields.get("month");
-    out.push_str(&fmt_authors_apa(authors));
-    out.push(' ');
-    out.push_str(&fmt_year_month_apa(year, month, true));
-    out.push_str(title);
-    out.push('.');
-
-    out
-}
-
-fn fmt_techreport_apa(authors: Vec<OwnedFullName>, fields: BTreeMap<String, String>) -> String {
-    let mut out = String::new();
-    let title = fields.get("title").unwrap();
-    let year = fields.get("year");
-    let month = fields.get("month");
-    let number = fields.get("number").unwrap();
-    let institution = fields.get("institution").unwrap();
-    let address = fields.get("address").unwrap();
-    out.push_str(&fmt_authors_apa(authors));
-    out.push(' ');
-    out.push_str(&fmt_year_month_apa(year, month, true));
-    out.push_str(title);
-    out.push(' ');
-    out.push_str(&format!("(tech. rep. No. {}). ", number));
-    out.push_str(&format!("{}. ", institution));
-    out.push_str(&format!("{}.", address));
-
-    out
-}
-
-fn fmt_proceedings_apa(fields: BTreeMap<String, String>) -> String {
-    let mut out = String::new();
-    let title = fields.get("title").unwrap();
-    let year = fields.get("year");
-    let month = fields.get("month");
-    let editors_str = fields.get("editor").unwrap();
-    let (_tail, edrs) = and_seperated_names(editors_str).unwrap();
-    let editor_names: Vec<OwnedFullName> = edrs.into_iter().map(|n| n.into()).collect();
-    let volume = fields.get("volume").unwrap();
-    let publisher = fields.get("publisher").unwrap();
-    out.push_str(&fmt_authors_apa(editor_names));
-    out.push_str(" (Eds.). ");
-    out.push_str(&fmt_year_month_apa(year, month, true));
-    out.push_str(title);
-    out.push_str(&format!(" (Vol. {}). ", volume));
-    out.push_str(publisher);
-    out.push('.');
-    out
-}
-
-fn fmt_thesis_apa(
-    kind: ThesisKind,
-    authors: Vec<OwnedFullName>,
-    fields: BTreeMap<String, String>,
-) -> String {
-    let mut out = String::new();
-    let title = fields.get("title").unwrap();
-    let year = fields.get("year");
-    let month = fields.get("month");
-    let school = fields.get("school").unwrap();
-    out.push_str(&fmt_authors_apa(authors));
-    out.push(' ');
-    out.push_str(&fmt_year_month_apa(year, month, true));
-    out.push_str(title);
-    out.push(' ');
-    match kind {
-        ThesisKind::Phd => out.push_str(&format!("[Doctoral dissertation, {}].", school)),
-        ThesisKind::Msc => out.push_str(&format!("[Master's thesis, {}].", school)),
-    };
-    out
-}
-
-fn fmt_misc_apa(authors: Vec<OwnedFullName>, fields: BTreeMap<String, String>) -> String {
-    let mut out = String::new();
-    let title = fields.get("title").unwrap();
-    let year = fields.get("year");
-    let month = fields.get("month");
-    out.push_str(&fmt_authors_apa(authors));
-    out.push_str(". ");
-    out.push_str(&fmt_year_month_apa(year, month, true));
-    out.push_str(title);
-    if let Some(n) = fields.get("note") {
-        out.push_str(&format!(" [{}]", n))
-    }
-    out.push('.');
-
-    out
-}
-
-fn fmt_manual_apa(authors: Vec<OwnedFullName>, fields: BTreeMap<String, String>) -> String {
-    let mut out = String::new();
-    let title = fields.get("title").unwrap();
-    let year = fields.get("year");
-    let month = fields.get("month");
-    let organization = fields.get("organization").unwrap();
-    let address = fields.get("address").unwrap();
-    out.push_str(&fmt_authors_apa(authors));
-    out.push_str(". ");
-    out.push_str(&fmt_year_month_apa(year, month, true));
-    out.push_str(title);
-    out.push_str(". ");
-    out.push_str(&format!("{}. ", organization));
-    out.push_str(&format!("{}.", address));
-
-    out
-}
-
-fn fmt_inproceedings_apa(authors: Vec<OwnedFullName>, fields: BTreeMap<String, String>) -> String {
-    let mut out = String::new();
-    let title = fields.get("title").unwrap();
-    let year = fields.get("year");
-    let month = fields.get("month");
-    let booktitle = fields.get("booktitle").unwrap();
-    let pages = fields.get("pages").unwrap();
-    out.push_str(&fmt_authors_apa(authors));
-    out.push(' ');
-    out.push_str(&fmt_year_month_apa(year, month, true));
-    out.push_str(title);
-    out.push_str(". ");
-    out.push_str(booktitle);
-    out.push_str(", ");
-    out.push_str(pages);
-    out.push('.');
-
-    out
-}
-
-fn fmt_incollection_apa(authors: Vec<OwnedFullName>, fields: BTreeMap<String, String>) -> String {
-    let mut out = String::new();
-    let title = fields.get("title").unwrap();
-    let year = fields.get("year");
-    let month = fields.get("month");
-    let booktitle = fields.get("booktitle").unwrap();
-    let pages = fields.get("pages").unwrap();
-    let editors_str = fields.get("editor").unwrap();
-    let (_tail, edrs) = and_seperated_names(editors_str).unwrap();
-    let editor_names: Vec<OwnedFullName> = edrs.into_iter().map(|n| n.into()).collect();
-    let publisher = fields.get("publisher").unwrap();
-    out.push_str(&fmt_authors_apa(authors));
-    out.push(' ');
-    out.push_str(&fmt_year_month_apa(year, month, true));
-    out.push_str(title);
-    out.push_str(". In ");
-    out.push_str(&fmt_editors_apa(editor_names));
-    out.push_str(" (Eds.), ");
-    out.push_str(booktitle);
-    out.push_str(&format!(" (pp. {}). ", pages));
-    out.push_str(publisher);
-    out.push('.');
-
-    out
-}
-
-fn fmt_inbook_apa(authors: Vec<OwnedFullName>, fields: BTreeMap<String, String>) -> String {
-    let mut out = String::new();
-    let title = fields.get("title").unwrap();
-    let year = fields.get("year");
-    let month = fields.get("month");
-    let booktitle = fields.get("booktitle").unwrap();
-    let publisher = fields.get("publisher").unwrap();
-    let pages = fields.get("pages").unwrap();
-    out.push_str(&fmt_authors_apa(authors));
-    out.push(' ');
-    out.push_str(&fmt_year_month_apa(year, month, true));
-    out.push_str(title);
-    out.push_str(". In ");
-    out.push_str(booktitle);
-    out.push_str(&format!(" (pp. {}). ", pages));
-    out.push_str(publisher);
-    out.push('.');
-
-    out
-}
-
-fn fmt_conference_apa(authors: Vec<OwnedFullName>, fields: BTreeMap<String, String>) -> String {
-    let mut out = String::new();
-    let publisher = fields.get("publisher").unwrap();
-    let year = fields.get("year").unwrap();
-    let booktitle = fields.get("booktitle").unwrap();
-    let pages = fields.get("pages").unwrap();
-    let title = fields.get("title").unwrap();
-    let editors_str = fields.get("editor").unwrap();
-    let (_tail, edrs) = and_seperated_names(editors_str).unwrap();
-    let editor_names: Vec<OwnedFullName> = edrs.into_iter().map(|n| n.into()).collect();
-    out.push_str(&fmt_authors_apa(authors));
-    out.push(' ');
-    out.push_str(&format!("({}). ", &year));
-    out.push_str(&format!("{} ", &title));
-    out.push_str(&format!("[Review of {}]. ", &title));
-    out.push_str(&format!("In {} (Ed.), ", &fmt_editors_apa(editor_names)));
-    out.push_str(&(&booktitle).to_string());
-    out.push_str(&format!(" (pp. {}).", &pages));
-    out.push_str(&format!(" {}.", &publisher));
-
-    out
-}
-
-fn fmt_booklet_apa(authors: Vec<OwnedFullName>, fields: BTreeMap<String, String>) -> String {
-    let mut out = String::new();
-    let title = fields.get("title").unwrap();
-    let year = fields.get("year");
-    let month = fields.get("month");
-    let howpublished = fields.get("howpublished").unwrap();
-
-    out.push_str(&fmt_authors_apa(authors));
-    out.push(' ');
-    out.push_str(title);
-    out.push_str(". ");
-    out.push_str(howpublished);
-    out.push_str(". ");
-    out.push_str(&fmt_year_month_apa(year, month, false));
-
-    out
-}
-
-fn fmt_book_apa(authors: Vec<OwnedFullName>, fields: BTreeMap<String, String>) -> String {
-    let mut out = String::new();
-    let title = fields.get("title").unwrap();
-    let year = fields.get("year");
-    let month = fields.get("month");
-    let publisher = fields.get("publisher").unwrap();
-    out.push_str(&fmt_authors_apa(authors));
-    out.push(' ');
-    out.push_str(&fmt_year_month_apa(year, month, true));
-    out.push_str(title);
-    out.push_str(". ");
-    out.push_str(publisher);
-    out.push('.');
-
-    out
-}
-
-fn fmt_year_month_apa(year: Option<&String>, month: Option<&String>, braces: bool) -> String {
-    let mut out = String::new();
-    if braces {
-        out.push('(');
-    };
-    match (year, month) {
-        (None, None) => out.push_str("n.d."),
-        (None, Some(_)) => out.push_str("n.d."),
-
-        (Some(y), None) => {
-            out.push_str(y);
-        }
-        (Some(y), Some(m)) => {
-            // years generally don't get represented as anything other than number so unwrapping here is fine
-            let y_parsed = y.parse::<i32>().unwrap();
-            let m_parsed = m.parse::<u32>();
-            let date_formatted = match m_parsed {
-                Ok(m) => {
-                    let date = NaiveDate::from_ymd_opt(y_parsed, m, 1).unwrap();
-                    date.format("%B").to_string()
-                }
-                // if it's not a number just capitalise the first letter
-                Err(_) => m[0..1].to_uppercase() + &m[1..],
-            };
-            out.push_str(y);
-            out.push_str(", ");
-            out.push_str(&date_formatted);
-        }
-    };
-    if braces {
-        out.push_str("). ");
-    } else {
+impl Stylizer for ApaStylizer {
+    fn fmt_unpublished(authors: Vec<OwnedFullName>, fields: BTreeMap<String, String>) -> String {
+        let mut out = String::new();
+        let title = fields.get("title").unwrap();
+        let year = fields.get("year");
+        let month = fields.get("month");
+        out.push_str(&Self::fmt_authors(authors));
+        out.push(' ');
+        out.push_str(&Self::fmt_year_month(year, month, true));
+        out.push_str(title);
         out.push('.');
-    };
 
-    out
-}
-
-fn fmt_article_apa(authors: Vec<OwnedFullName>, fields: BTreeMap<String, String>) -> String {
-    let title = fields.get("title").unwrap().clone();
-    let volume = fields.get("volume").unwrap_or(&String::new()).clone();
-    let pages = fields.get("pages");
-    let number = fields.get("number").unwrap_or(&String::new()).clone();
-    let journal = fields.get("journal").unwrap_or(&String::new()).clone();
-    let year = fields.get("year").map(|s| s.to_string());
-    let doi = fields.get("doi");
-    let mut out = String::new();
-    out.push_str(&fmt_authors_apa(authors.clone()));
-    out.push(' ');
-    out.push_str(&fmt_pub_date_apa(year));
-    out.push(' ');
-    out.push_str(&fmt_title_apa(title));
-    out.push(' ');
-    out.push_str(&fmt_journal_apa(journal));
-    out.push(' ');
-    out.push_str(&fmt_vol_issue_apa(volume, number));
-    out.push(' ');
-    if let Some(p) = pages {
-        out.push_str(&fmt_pages_apa(p));
-    };
-
-    if let Some(d) = doi {
-        if pages.is_some() {
-            out.push(' ');
-        }
-        out.push_str(d);
+        out
     }
 
-    out
+    fn fmt_techreport(authors: Vec<OwnedFullName>, fields: BTreeMap<String, String>) -> String {
+        let mut out = String::new();
+        let title = fields.get("title").unwrap();
+        let year = fields.get("year");
+        let month = fields.get("month");
+        let number = fields.get("number").unwrap();
+        let institution = fields.get("institution").unwrap();
+        let address = fields.get("address").unwrap();
+        out.push_str(&Self::fmt_authors(authors));
+        out.push(' ');
+        out.push_str(&Self::fmt_year_month(year, month, true));
+        out.push_str(title);
+        out.push(' ');
+        out.push_str(&format!("(tech. rep. No. {}). ", number));
+        out.push_str(&format!("{}. ", institution));
+        out.push_str(&format!("{}.", address));
+
+        out
+    }
+
+    fn fmt_proceedings(fields: BTreeMap<String, String>) -> String {
+        let mut out = String::new();
+        let title = fields.get("title").unwrap();
+        let year = fields.get("year");
+        let month = fields.get("month");
+        let editors_str = fields.get("editor").unwrap();
+        let (_tail, edrs) = and_seperated_names(editors_str).unwrap();
+        let editor_names: Vec<OwnedFullName> = edrs.into_iter().map(|n| n.into()).collect();
+        let volume = fields.get("volume").unwrap();
+        let publisher = fields.get("publisher").unwrap();
+        out.push_str(&Self::fmt_authors(editor_names));
+        out.push_str(" (Eds.). ");
+        out.push_str(&Self::fmt_year_month(year, month, true));
+        out.push_str(title);
+        out.push_str(&format!(" (Vol. {}). ", volume));
+        out.push_str(publisher);
+        out.push('.');
+        out
+    }
+
+    fn fmt_thesis(
+        kind: ThesisKind,
+        authors: Vec<OwnedFullName>,
+        fields: BTreeMap<String, String>,
+    ) -> String {
+        let mut out = String::new();
+        let title = fields.get("title").unwrap();
+        let year = fields.get("year");
+        let month = fields.get("month");
+        let school = fields.get("school").unwrap();
+        out.push_str(&Self::fmt_authors(authors));
+        out.push(' ');
+        out.push_str(&Self::fmt_year_month(year, month, true));
+        out.push_str(title);
+        out.push(' ');
+        match kind {
+            ThesisKind::Phd => out.push_str(&format!("[Doctoral dissertation, {}].", school)),
+            ThesisKind::Msc => out.push_str(&format!("[Master's thesis, {}].", school)),
+        };
+        out
+    }
+
+    fn fmt_misc(authors: Vec<OwnedFullName>, fields: BTreeMap<String, String>) -> String {
+        let mut out = String::new();
+        let title = fields.get("title").unwrap();
+        let year = fields.get("year");
+        let month = fields.get("month");
+        out.push_str(&Self::fmt_authors(authors));
+        out.push_str(". ");
+        out.push_str(&Self::fmt_year_month(year, month, true));
+        out.push_str(title);
+        if let Some(n) = fields.get("note") {
+            out.push_str(&format!(" [{}]", n))
+        }
+        out.push('.');
+
+        out
+    }
+
+    fn fmt_manual(authors: Vec<OwnedFullName>, fields: BTreeMap<String, String>) -> String {
+        let mut out = String::new();
+        let title = fields.get("title").unwrap();
+        let year = fields.get("year");
+        let month = fields.get("month");
+        let organization = fields.get("organization").unwrap();
+        let address = fields.get("address").unwrap();
+        out.push_str(&Self::fmt_authors(authors));
+        out.push_str(". ");
+        out.push_str(&Self::fmt_year_month(year, month, true));
+        out.push_str(title);
+        out.push_str(". ");
+        out.push_str(&format!("{}. ", organization));
+        out.push_str(&format!("{}.", address));
+
+        out
+    }
+
+    fn fmt_inproceedings(authors: Vec<OwnedFullName>, fields: BTreeMap<String, String>) -> String {
+        let mut out = String::new();
+        let title = fields.get("title").unwrap();
+        let year = fields.get("year");
+        let month = fields.get("month");
+        let booktitle = fields.get("booktitle").unwrap();
+        let pages = fields.get("pages").unwrap();
+        out.push_str(&Self::fmt_authors(authors));
+        out.push(' ');
+        out.push_str(&Self::fmt_year_month(year, month, true));
+        out.push_str(title);
+        out.push_str(". ");
+        out.push_str(booktitle);
+        out.push_str(", ");
+        out.push_str(pages);
+        out.push('.');
+
+        out
+    }
+
+    fn fmt_incollection(authors: Vec<OwnedFullName>, fields: BTreeMap<String, String>) -> String {
+        let mut out = String::new();
+        let title = fields.get("title").unwrap();
+        let year = fields.get("year");
+        let month = fields.get("month");
+        let booktitle = fields.get("booktitle").unwrap();
+        let pages = fields.get("pages").unwrap();
+        let editors_str = fields.get("editor").unwrap();
+        let (_tail, edrs) = and_seperated_names(editors_str).unwrap();
+        let editor_names: Vec<OwnedFullName> = edrs.into_iter().map(|n| n.into()).collect();
+        let publisher = fields.get("publisher").unwrap();
+        out.push_str(&Self::fmt_authors(authors));
+        out.push(' ');
+        out.push_str(&Self::fmt_year_month(year, month, true));
+        out.push_str(title);
+        out.push_str(". In ");
+        out.push_str(&fmt_editors(editor_names));
+        out.push_str(" (Eds.), ");
+        out.push_str(booktitle);
+        out.push_str(&format!(" (pp. {}). ", pages));
+        out.push_str(publisher);
+        out.push('.');
+
+        out
+    }
+
+    fn fmt_inbook(authors: Vec<OwnedFullName>, fields: BTreeMap<String, String>) -> String {
+        let mut out = String::new();
+        let title = fields.get("title").unwrap();
+        let year = fields.get("year");
+        let month = fields.get("month");
+        let booktitle = fields.get("booktitle").unwrap();
+        let publisher = fields.get("publisher").unwrap();
+        let pages = fields.get("pages").unwrap();
+        out.push_str(&Self::fmt_authors(authors));
+        out.push(' ');
+        out.push_str(&Self::fmt_year_month(year, month, true));
+        out.push_str(title);
+        out.push_str(". In ");
+        out.push_str(booktitle);
+        out.push_str(&format!(" (pp. {}). ", pages));
+        out.push_str(publisher);
+        out.push('.');
+
+        out
+    }
+
+    fn fmt_conference(authors: Vec<OwnedFullName>, fields: BTreeMap<String, String>) -> String {
+        let mut out = String::new();
+        let publisher = fields.get("publisher").unwrap();
+        let year = fields.get("year").unwrap();
+        let booktitle = fields.get("booktitle").unwrap();
+        let pages = fields.get("pages").unwrap();
+        let title = fields.get("title").unwrap();
+        let editors_str = fields.get("editor").unwrap();
+        let (_tail, edrs) = and_seperated_names(editors_str).unwrap();
+        let editor_names: Vec<OwnedFullName> = edrs.into_iter().map(|n| n.into()).collect();
+        out.push_str(&Self::fmt_authors(authors));
+        out.push(' ');
+        out.push_str(&format!("({}). ", &year));
+        out.push_str(&format!("{} ", &title));
+        out.push_str(&format!("[Review of {}]. ", &title));
+        out.push_str(&format!("In {} (Ed.), ", &fmt_editors(editor_names)));
+        out.push_str(&(&booktitle).to_string());
+        out.push_str(&format!(" (pp. {}).", &pages));
+        out.push_str(&format!(" {}.", &publisher));
+
+        out
+    }
+
+    fn fmt_booklet(authors: Vec<OwnedFullName>, fields: BTreeMap<String, String>) -> String {
+        let mut out = String::new();
+        let title = fields.get("title").unwrap();
+        let year = fields.get("year");
+        let month = fields.get("month");
+        let howpublished = fields.get("howpublished").unwrap();
+
+        out.push_str(&Self::fmt_authors(authors));
+        out.push(' ');
+        out.push_str(title);
+        out.push_str(". ");
+        out.push_str(howpublished);
+        out.push_str(". ");
+        out.push_str(&Self::fmt_year_month(year, month, false));
+
+        out
+    }
+
+    fn fmt_book(authors: Vec<OwnedFullName>, fields: BTreeMap<String, String>) -> String {
+        let mut out = String::new();
+        let title = fields.get("title").unwrap();
+        let year = fields.get("year");
+        let month = fields.get("month");
+        let publisher = fields.get("publisher").unwrap();
+        out.push_str(&Self::fmt_authors(authors));
+        out.push(' ');
+        out.push_str(&Self::fmt_year_month(year, month, true));
+        out.push_str(title);
+        out.push_str(". ");
+        out.push_str(publisher);
+        out.push('.');
+
+        out
+    }
+
+    fn fmt_year_month(year: Option<&String>, month: Option<&String>, braces: bool) -> String {
+        let mut out = String::new();
+        if braces {
+            out.push('(');
+        };
+        match (year, month) {
+            (None, None) => out.push_str("n.d."),
+            (None, Some(_)) => out.push_str("n.d."),
+
+            (Some(y), None) => {
+                out.push_str(y);
+            }
+            (Some(y), Some(m)) => {
+                // years generally don't get represented as anything other than number so unwrapping here is fine
+                let y_parsed = y.parse::<i32>().unwrap();
+                let m_parsed = m.parse::<u32>();
+                let date_formatted = match m_parsed {
+                    Ok(m) => {
+                        let date = NaiveDate::from_ymd_opt(y_parsed, m, 1).unwrap();
+                        date.format("%B").to_string()
+                    }
+                    // if it's not a number just capitalise the first letter
+                    Err(_) => m[0..1].to_uppercase() + &m[1..],
+                };
+                out.push_str(y);
+                out.push_str(", ");
+                out.push_str(&date_formatted);
+            }
+        };
+        if braces {
+            out.push_str("). ");
+        } else {
+            out.push('.');
+        };
+
+        out
+    }
+
+    fn fmt_article(authors: Vec<OwnedFullName>, fields: BTreeMap<String, String>) -> String {
+        let title = fields.get("title").unwrap().clone();
+        let volume = fields.get("volume").unwrap_or(&String::new()).clone();
+        let pages = fields.get("pages");
+        let number = fields.get("number").unwrap_or(&String::new()).clone();
+        let journal = fields.get("journal").unwrap_or(&String::new()).clone();
+        let year = fields.get("year").map(|s| s.to_string());
+        let doi = fields.get("doi");
+        let mut out = String::new();
+        out.push_str(&Self::fmt_authors(authors.clone()));
+        out.push(' ');
+        out.push_str(&fmt_pub_date(year));
+        out.push(' ');
+        out.push_str(&fmt_title(title));
+        out.push(' ');
+        out.push_str(&fmt_journal(journal));
+        out.push(' ');
+        out.push_str(&fmt_vol_issue(volume, number));
+        out.push(' ');
+        if let Some(p) = pages {
+            out.push_str(&fmt_pages(p));
+        };
+
+        if let Some(d) = doi {
+            if pages.is_some() {
+                out.push(' ');
+            }
+            out.push_str(d);
+        }
+
+        out
+    }
+
+    fn fmt_authors(mut authors: Vec<OwnedFullName>) -> String {
+        match &authors.len() {
+            0 => String::new(),
+            1 => {
+                let author = authors.remove(0);
+                fmt_single_author(author)
+            }
+            2 => {
+                let author1 = authors.remove(0);
+                let author2 = authors.remove(0);
+                format!(
+                    "{}, & {}",
+                    fmt_single_author(author1),
+                    fmt_single_author(author2)
+                )
+            }
+            3..=21 => {
+                let last_author = authors.remove(authors.len() - 1);
+                format!(
+                    "{}, & {}",
+                    authors
+                        .into_iter()
+                        .map(fmt_single_author)
+                        .collect::<Vec<String>>()
+                        .join(", "),
+                    fmt_single_author(last_author)
+                )
+            }
+            22.. => {
+                let last_author = authors.remove(authors.len() - 1);
+                let listed_authors = authors.drain(0..19);
+                format!(
+                    "{},...{}",
+                    listed_authors
+                        .into_iter()
+                        .map(fmt_single_author)
+                        .collect::<Vec<String>>()
+                        .join(", "),
+                    fmt_single_author(last_author)
+                )
+            }
+        }
+    }
 }
 
-fn fmt_pages_apa(pages: &String) -> String {
+fn fmt_pages(pages: &String) -> String {
     format!("{}.", pages)
 }
-fn fmt_journal_apa(journal: String) -> String {
+fn fmt_journal(journal: String) -> String {
     format!("{},", journal)
 }
-fn fmt_vol_issue_apa(vol: String, number: String) -> String {
+fn fmt_vol_issue(vol: String, number: String) -> String {
     format!("{} ({}),", vol, number)
 }
-fn fmt_authors_apa(mut authors: Vec<OwnedFullName>) -> String {
+
+fn fmt_editors(mut authors: Vec<OwnedFullName>) -> String {
     match &authors.len() {
         0 => String::new(),
         1 => {
             let author = authors.remove(0);
-            fmt_single_author_apa(author)
+            fmt_single_editor(author)
         }
         2 => {
             let author1 = authors.remove(0);
             let author2 = authors.remove(0);
             format!(
-                "{}, & {}",
-                fmt_single_author_apa(author1),
-                fmt_single_author_apa(author2)
+                "{} & {}",
+                fmt_single_editor(author1),
+                fmt_single_editor(author2)
             )
         }
         3..=21 => {
             let last_author = authors.remove(authors.len() - 1);
             format!(
-                "{}, & {}",
+                "{} & {}",
                 authors
                     .into_iter()
-                    .map(fmt_single_author_apa)
+                    .map(fmt_single_author)
                     .collect::<Vec<String>>()
-                    .join(", "),
-                fmt_single_author_apa(last_author)
+                    .join(" "),
+                fmt_single_editor(last_author)
             )
         }
         22.. => {
@@ -385,66 +406,23 @@ fn fmt_authors_apa(mut authors: Vec<OwnedFullName>) -> String {
                 "{},...{}",
                 listed_authors
                     .into_iter()
-                    .map(fmt_single_author_apa)
-                    .collect::<Vec<String>>()
-                    .join(", "),
-                fmt_single_author_apa(last_author)
-            )
-        }
-    }
-}
-fn fmt_editors_apa(mut authors: Vec<OwnedFullName>) -> String {
-    match &authors.len() {
-        0 => String::new(),
-        1 => {
-            let author = authors.remove(0);
-            fmt_single_editor_apa(author)
-        }
-        2 => {
-            let author1 = authors.remove(0);
-            let author2 = authors.remove(0);
-            format!(
-                "{} & {}",
-                fmt_single_editor_apa(author1),
-                fmt_single_editor_apa(author2)
-            )
-        }
-        3..=21 => {
-            let last_author = authors.remove(authors.len() - 1);
-            format!(
-                "{} & {}",
-                authors
-                    .into_iter()
-                    .map(fmt_single_author_apa)
+                    .map(fmt_single_author)
                     .collect::<Vec<String>>()
                     .join(" "),
-                fmt_single_editor_apa(last_author)
-            )
-        }
-        22.. => {
-            let last_author = authors.remove(authors.len() - 1);
-            let listed_authors = authors.drain(0..19);
-            format!(
-                "{},...{}",
-                listed_authors
-                    .into_iter()
-                    .map(fmt_single_author_apa)
-                    .collect::<Vec<String>>()
-                    .join(" "),
-                fmt_single_editor_apa(last_author)
+                fmt_single_editor(last_author)
             )
         }
     }
 }
 
-fn fmt_pub_date_apa(year: Option<String>) -> String {
+fn fmt_pub_date(year: Option<String>) -> String {
     format!("({}).", year.unwrap_or_else(|| "n.d.".to_string()))
 }
-fn fmt_title_apa(title: String) -> String {
+fn fmt_title(title: String) -> String {
     format!("{}.", title)
 }
 
-fn fmt_single_author_apa(name: OwnedFullName) -> String {
+fn fmt_single_author(name: OwnedFullName) -> String {
     let mut out = String::new();
     if !name.last.is_empty() {
         out.push_str(&name.last.join(" "));
@@ -464,7 +442,8 @@ fn fmt_single_author_apa(name: OwnedFullName) -> String {
     };
     out
 }
-fn fmt_single_editor_apa(name: OwnedFullName) -> String {
+
+fn fmt_single_editor(name: OwnedFullName) -> String {
     let mut out = String::new();
     if !name.first.is_empty() {
         out.push_str(
@@ -489,6 +468,7 @@ mod test {
     use std::path::PathBuf;
 
     use crate::parsing::bibligraphy::Bibliography;
+    use crate::ReferenceStyle;
 
     use super::*;
     use anyhow::Result;
@@ -501,7 +481,7 @@ mod test {
             von: vec![],
             title: vec![],
         };
-        let formated = fmt_authors_apa(vec![author]);
+        let formated = ApaStylizer::fmt_authors(vec![author]);
         assert_eq!(formated, "Lovelace Augusta, A. M.");
 
         Ok(())
@@ -522,7 +502,7 @@ mod test {
                 title: vec![],
             },
         ];
-        let formated = fmt_authors_apa(authors);
+        let formated = ApaStylizer::fmt_authors(authors);
         assert_eq!(formated, "Lovelace Augusta, A. M., & Noether, A. E.");
 
         Ok(())
@@ -549,7 +529,7 @@ mod test {
                 title: vec![],
             },
         ];
-        let formated = fmt_authors_apa(authors);
+        let formated = ApaStylizer::fmt_authors(authors);
         assert_eq!(
             formated,
             "Lovelace Augusta, A. M., Noether, A. E., & Germain, S."
@@ -705,7 +685,7 @@ mod test {
                 title: vec![],
             },
         ];
-        let formated = fmt_authors_apa(authors);
+        let formated = ApaStylizer::fmt_authors(authors);
         assert_eq!(
             formated,
             "Lovelace Augusta, A. M., Noether, A. E., Germain, S., Kovalevskaya, S., Vaughn, D., Mirzakhani, M., Lovelace Augusta, A. M., Noether, A. E., Germain, S., Kovalevskaya, S., Vaughn, D., Mirzakhani, M., Lovelace Augusta, A. M., Noether, A. E., Germain, S., Kovalevskaya, S., Vaughn, D., Mirzakhani, M., Lovelace Augusta, A. M.,...Mirzakhani, M."
@@ -720,7 +700,7 @@ mod test {
         let formatted_citation = "Breiman, L. (2001). Random forests. Machine learning, 45 (1), 5-32. https://doi.org/10.1023/a:1010933404324";
         let entries = Bibliography::from_file(PathBuf::from("cite.bib"))?;
         let entry = entries.get_entry(key.to_string()).unwrap();
-        let citation = fmt_reference_apa(entry);
+        let citation = ApaStylizer::fmt_reference(entry);
         assert_eq!(citation, formatted_citation);
         Ok(())
     }
@@ -730,7 +710,7 @@ mod test {
         let formatted_citation= "Liao, J., Cao, X., Zhao, L., Wang, J., Gao, Z., Wang, M. C., & Huang, Y. (2016). The importance of neutral and niche processes for bacterial community assembly differs between habitat generalists and specialists. FEMS Microbiology Ecology, 92 (11), https://doi.org/10.1093/femsec/fiw174";
         let entries = Bibliography::from_file(PathBuf::from("cite.bib"))?;
         let entry = entries.get_entry(key.to_string()).unwrap();
-        let citation = fmt_reference_apa(entry);
+        let citation = ApaStylizer::fmt_reference(entry);
         assert_eq!(citation, formatted_citation);
         Ok(())
     }
@@ -740,7 +720,7 @@ mod test {
         let formatted_citation= "Cohen, P. J. (1963). The independence of the continuum hypothesis. Proceedings of the National Academy of Sciences, 50 (6), 1143-1148.";
         let entries = Bibliography::from_file(PathBuf::from("cite.bib"))?;
         let entry = entries.get_entry(key.to_string()).unwrap();
-        let citation = fmt_reference_apa(entry);
+        let citation = ApaStylizer::fmt_reference(entry);
         assert_eq!(citation, formatted_citation);
         Ok(())
     }
@@ -750,7 +730,7 @@ mod test {
         let formatted_citation= "Susskind, L., & Hrabovsky, G. (2014). Classical mechanics: the theoretical minimum. Penguin Random House.";
         let entries = Bibliography::from_file(PathBuf::from("cite.bib"))?;
         let entry = entries.get_entry(key.to_string()).unwrap();
-        let citation = fmt_reference_apa(entry);
+        let citation = ApaStylizer::fmt_reference(entry);
         assert_eq!(citation, formatted_citation);
         Ok(())
     }
@@ -760,7 +740,7 @@ mod test {
         let formatted_citation= "Swetla, M. Canoe tours in Sweden. Distributed at the Stockholm Tourist Office. 2015, July.";
         let entries = Bibliography::from_file(PathBuf::from("cite.bib"))?;
         let entry = entries.get_entry(key.to_string()).unwrap();
-        let citation = fmt_reference_apa(entry);
+        let citation = ApaStylizer::fmt_reference(entry);
         assert_eq!(citation, formatted_citation);
         Ok(())
     }
@@ -770,7 +750,7 @@ mod test {
         let formatted_citation= "Urry, L. A., Cain, M. L., Wasserman, S. A., Minorsky, P. V., & Reece, J. B. (2016). Photosynthesis. In Campbell biology (pp. 187-221). Pearson.";
         let entries = Bibliography::from_file(PathBuf::from("cite.bib"))?;
         let entry = entries.get_entry(key.to_string()).unwrap();
-        let citation = fmt_reference_apa(entry);
+        let citation = ApaStylizer::fmt_reference(entry);
         assert_eq!(citation, formatted_citation);
         Ok(())
     }
@@ -780,7 +760,7 @@ mod test {
         let formatted_citation= "Shapiro, H. M. (2018). Flow cytometry: The glass is half full. In T. S. Hawley & R. G. Hawley (Eds.), Flow cytometry protocols (pp. 1-10). Springer.";
         let entries = Bibliography::from_file(PathBuf::from("cite.bib"))?;
         let entry = entries.get_entry(key.to_string()).unwrap();
-        let citation = fmt_reference_apa(entry);
+        let citation = ApaStylizer::fmt_reference(entry);
         assert_eq!(citation, formatted_citation);
         Ok(())
     }
@@ -790,7 +770,7 @@ mod test {
         let formatted_citation= "Holleis, P., Wagner, M., & Koolwaaij, J. (2010). Studying mobile context-aware social services in the wild. Proc. of the 6th Nordic Conf. on Human-Computer Interaction, 207-216.";
         let entries = Bibliography::from_file(PathBuf::from("cite.bib"))?;
         let entry = entries.get_entry(key.to_string()).unwrap();
-        let citation = fmt_reference_apa(entry);
+        let citation = ApaStylizer::fmt_reference(entry);
         assert_eq!(citation, formatted_citation);
         Ok(())
     }
@@ -800,7 +780,7 @@ mod test {
         let formatted_citation= "R Core Team. (2018). R: A language and environment for statistical computing. R Foundation for Statistical Computing. Vienna, Austria.";
         let entries = Bibliography::from_file(PathBuf::from("cite.bib"))?;
         let entry = entries.get_entry(key.to_string()).unwrap();
-        let citation = fmt_reference_apa(entry);
+        let citation = ApaStylizer::fmt_reference(entry);
         assert_eq!(citation, formatted_citation);
         Ok(())
     }
@@ -810,7 +790,7 @@ mod test {
         let formatted_citation= "Tang, J. (1996, September). Spin structure of the nucleon in the asymptotic limit [Master's thesis, Massachusetts Institute of Technology].";
         let entries = Bibliography::from_file(PathBuf::from("cite.bib"))?;
         let entry = entries.get_entry(key.to_string()).unwrap();
-        let citation = fmt_reference_apa(entry);
+        let citation = ApaStylizer::fmt_reference(entry);
         assert_eq!(citation, formatted_citation);
         Ok(())
     }
@@ -821,7 +801,7 @@ mod test {
             "NASA. (2015). Pluto: The 'other' red planet [Accessed: 2018-12-06].";
         let entries = Bibliography::from_file(PathBuf::from("cite.bib"))?;
         let entry = entries.get_entry(key.to_string()).unwrap();
-        let citation = fmt_reference_apa(entry);
+        let citation = ApaStylizer::fmt_reference(entry);
         assert_eq!(citation, formatted_citation);
         Ok(())
     }
@@ -831,7 +811,7 @@ mod test {
         let formatted_citation= "Rempel, R. C. (1956, June). Relaxation effects for coupled nuclear spins [Doctoral dissertation, Stanford University].";
         let entries = Bibliography::from_file(PathBuf::from("cite.bib"))?;
         let entry = entries.get_entry(key.to_string()).unwrap();
-        let citation = fmt_reference_apa(entry);
+        let citation = ApaStylizer::fmt_reference(entry);
         assert_eq!(citation, formatted_citation);
         Ok(())
     }
@@ -841,7 +821,7 @@ mod test {
         let formatted_citation= "Stepney, S., & Verlan, S. (Eds.). (2018). Proceedings of the 17th international conference on computation and natural computation, fontainebleau, france (Vol. 10867). Springer.";
         let entries = Bibliography::from_file(PathBuf::from("cite.bib"))?;
         let entry = entries.get_entry(key.to_string()).unwrap();
-        let citation = fmt_reference_apa(entry);
+        let citation = ApaStylizer::fmt_reference(entry);
         assert_eq!(citation, formatted_citation);
         Ok(())
     }
@@ -851,7 +831,7 @@ mod test {
         let formatted_citation= "Bennett, V., Bowman, K., & Wright, S. (2018, September). Wasatch Solar Project final report (tech. rep. No. DOE-SLC-6903-1). Salt Lake City Corporation. Salt Lake City, UT.";
         let entries = Bibliography::from_file(PathBuf::from("cite.bib"))?;
         let entry = entries.get_entry(key.to_string()).unwrap();
-        let citation = fmt_reference_apa(entry);
+        let citation = ApaStylizer::fmt_reference(entry);
         assert_eq!(citation, formatted_citation);
         Ok(())
     }
@@ -861,7 +841,7 @@ mod test {
         let formatted_citation = "Suresh, M. (2006). Evolution: A revised theory.";
         let entries = Bibliography::from_file(PathBuf::from("cite.bib"))?;
         let entry = entries.get_entry(key.to_string()).unwrap();
-        let citation = fmt_reference_apa(entry);
+        let citation = ApaStylizer::fmt_reference(entry);
         assert_eq!(citation, formatted_citation);
         Ok(())
     }
@@ -871,7 +851,7 @@ mod test {
         let formatted_citation= "Smith, J., & Doe, J. (2022). The Effects of Climate Change [Review of The Effects of Climate Change]. In B. Johnson (Ed.), Proceedings of the Annual Conference on Climate Change (pp. 55-62). Springer.";
         let entries = Bibliography::from_file(PathBuf::from("cite.bib"))?;
         let entry = entries.get_entry(key.to_string()).unwrap();
-        let citation = fmt_reference_apa(entry);
+        let citation = ApaStylizer::fmt_reference(entry);
         assert_eq!(citation, formatted_citation);
         Ok(())
     }

--- a/src/styles/apa.rs
+++ b/src/styles/apa.rs
@@ -42,7 +42,8 @@ impl<T: Formatter> Stylizer for ApaStylizer<T> {
         fields: BTreeMap<String, String>,
     ) -> String {
         let mut out = String::new();
-        let title = fields.get("title").unwrap();
+        let mut title = fields.get("title").unwrap().clone();
+        self.fmt.italics(&mut title);
         let year = fields.get("year");
         let month = fields.get("month");
         let number = fields.get("number").unwrap();
@@ -53,7 +54,7 @@ impl<T: Formatter> Stylizer for ApaStylizer<T> {
         out.push('(');
         out.push_str(&Self::fmt_year_month(self, year, month));
         out.push_str("). ");
-        out.push_str(title);
+        out.push_str(&title);
         out.push(' ');
         out.push_str(&format!("(tech. rep. No. {}). ", number));
         out.push_str(&format!("{}. ", institution));
@@ -64,7 +65,8 @@ impl<T: Formatter> Stylizer for ApaStylizer<T> {
 
     fn fmt_proceedings(&self, fields: BTreeMap<String, String>) -> String {
         let mut out = String::new();
-        let title = fields.get("title").unwrap();
+        let mut title = fields.get("title").unwrap().clone();
+        self.fmt.italics(&mut title);
         let year = fields.get("year");
         let month = fields.get("month");
         let editors_str = fields.get("editor").unwrap();
@@ -77,7 +79,7 @@ impl<T: Formatter> Stylizer for ApaStylizer<T> {
         out.push('(');
         out.push_str(&Self::fmt_year_month(self, year, month));
         out.push_str("). ");
-        out.push_str(title);
+        out.push_str(&title);
         out.push_str(&format!(" (Vol. {}). ", volume));
         out.push_str(publisher);
         out.push('.');
@@ -329,7 +331,9 @@ impl<T: Formatter> Stylizer for ApaStylizer<T> {
         let volume = fields.get("volume").unwrap_or(&String::new()).clone();
         let pages = fields.get("pages");
         let number = fields.get("number").unwrap_or(&String::new()).clone();
-        let journal = fields.get("journal").unwrap_or(&String::new()).clone();
+        let mut journal = fields.get("journal").unwrap_or(&String::new()).clone();
+        journal.push_str(&format!(", {}", volume));
+        self.fmt.italics(&mut journal);
         let year = fields.get("year").map(|s| s.to_string());
         let doi = fields.get("doi");
         let mut out = String::new();
@@ -340,8 +344,7 @@ impl<T: Formatter> Stylizer for ApaStylizer<T> {
         out.push_str(&fmt_title(title));
         out.push(' ');
         out.push_str(&fmt_journal(journal));
-        out.push(' ');
-        out.push_str(&fmt_vol_issue(volume, number));
+        out.push_str(&format!(" ({}),", number));
         out.push(' ');
         if let Some(p) = pages {
             out.push_str(&fmt_pages(p));
@@ -351,7 +354,10 @@ impl<T: Formatter> Stylizer for ApaStylizer<T> {
             if pages.is_some() {
                 out.push(' ');
             }
-            out.push_str(d);
+            let mut cl = d.clone();
+            self.fmt.hyperlink(&mut cl);
+
+            out.push_str(&cl);
         }
 
         out
@@ -406,10 +412,7 @@ fn fmt_pages(pages: &String) -> String {
     format!("{}.", pages)
 }
 fn fmt_journal(journal: String) -> String {
-    format!("{},", journal)
-}
-fn fmt_vol_issue(vol: String, number: String) -> String {
-    format!("{} ({}),", vol, number)
+    journal.to_string()
 }
 
 fn fmt_editors(mut authors: Vec<OwnedFullName>) -> String {

--- a/src/styles/ieee.rs
+++ b/src/styles/ieee.rs
@@ -332,20 +332,24 @@ impl<T: Formatter> Stylizer for IeeeStylizer<T> {
         let title = fields.get("title").unwrap_or(&String::new()).clone();
         let volume = fields.get("volume").unwrap_or(&String::new()).clone();
         let pages = fields.get("pages");
-        let journal = fields.get("journal").unwrap_or(&String::new()).clone();
+        let mut journal = fields.get("journal").unwrap_or(&String::new()).clone();
+        journal.push(',');
+        self.fmt.italics(&mut journal);
         let number = fields.get("number").unwrap_or(&String::new()).clone();
         let year = fields.get("year");
         let month = fields.get("month");
         let doi = fields.get("doi");
         let issn = fields.get("issn");
-        let url = fields.get("url");
+        let url = fields.get("url").cloned().map(|mut s| {
+            self.fmt.hyperlink(&mut s);
+            s
+        });
         let mut out = String::new();
         out.push_str(&self.fmt_authors(authors.clone()));
         out.push_str(", ");
         out.push_str(&fmt_title(title));
         out.push(' ');
-        out.push_str(&format!("{}, vol. {}, no. {}", journal, &volume, &number));
-        out.push(',');
+        out.push_str(&format!("{} vol. {}, no. {},", journal, &volume, &number));
         if let Some(p) = pages {
             out.push_str(" pp. ");
             out.push_str(p);
@@ -366,7 +370,7 @@ impl<T: Formatter> Stylizer for IeeeStylizer<T> {
             out.push('.');
         };
 
-        if let Some(u) = url {
+        if let Some(ref u) = url {
             out.push_str(" [Online]. Available: ");
             out.push_str(u);
             out.push('.');

--- a/src/styles/ieee.rs
+++ b/src/styles/ieee.rs
@@ -1,415 +1,458 @@
 use std::collections::BTreeMap;
 
-use crate::parsing::{
-    entry::BibEntry,
-    names::{and_seperated_names, OwnedFullName},
+use crate::{
+    formaters::Formatter,
+    parsing::names::{and_seperated_names, OwnedFullName},
 };
 use chrono::prelude::*;
 use unicode_segmentation::UnicodeSegmentation;
 
-use super::ThesisKind;
+use super::{Stylizer, ThesisKind};
 
-pub fn fmt_reference_ieee(entry: BibEntry) -> String {
-    let (kind, _key, authors, fields) = entry.into_components();
-
-    match kind {
-        crate::parsing::entry::EntryType::Article => fmt_article_ieee(authors, fields),
-        crate::parsing::entry::EntryType::Book => fmt_book_ieee(authors, fields),
-        crate::parsing::entry::EntryType::Booklet => fmt_booklet_ieee(authors, fields),
-        crate::parsing::entry::EntryType::Conference => fmt_conference_ieee(authors, fields),
-        crate::parsing::entry::EntryType::Inbook => fmt_inbook_ieee(authors, fields),
-        crate::parsing::entry::EntryType::Incollection => fmt_incollection_ieee(authors, fields),
-        crate::parsing::entry::EntryType::Inproceedings => fmt_inprocedings_ieee(authors, fields),
-        crate::parsing::entry::EntryType::Manual => fmt_manual_ieee(authors, fields),
-        crate::parsing::entry::EntryType::Misc => fmt_misc_ieee(authors, fields),
-        crate::parsing::entry::EntryType::Mastersthesis => {
-            fmt_thesis_ieee(ThesisKind::Msc, authors, fields)
-        }
-        crate::parsing::entry::EntryType::Phdthesis => {
-            fmt_thesis_ieee(ThesisKind::Phd, authors, fields)
-        }
-        // full proceedings don't have authors, only editors, hence only passing fields
-        crate::parsing::entry::EntryType::Proceedings => fmt_procedings_ieee(fields),
-        crate::parsing::entry::EntryType::Techreport => fmt_tech_report_ieee(authors, fields),
-        crate::parsing::entry::EntryType::Unpublished => fmt_unpublished_ieee(authors, fields),
-    }
+#[derive(Default)]
+pub struct IeeeStylizer<T: Formatter> {
+    fmt: T,
 }
 
-fn fmt_book_ieee(authors: Vec<OwnedFullName>, fields: BTreeMap<String, String>) -> String {
-    let mut out = String::new();
-    let title = fields.get("title").unwrap_or(&String::new()).clone();
-    let publisher = fields.get("publisher").unwrap_or(&String::new()).clone();
-    let address = fields.get("address").unwrap_or(&String::new()).clone();
-    let year = fields.get("year").unwrap_or(&String::new()).clone();
-    out.push_str(&fmt_authors_ieee(authors.clone()));
-    out.push_str(", ");
-    out.push_str(&title);
-    out.push_str(". ");
-    out.push_str(&address);
-    out.push_str(": ");
-    out.push_str(&publisher);
-    out.push_str(", ");
-    out.push_str(&year);
-    out.push('.');
-    out
-}
-fn fmt_booklet_ieee(authors: Vec<OwnedFullName>, fields: BTreeMap<String, String>) -> String {
-    let mut out = String::new();
-    let title = fields.get("title").unwrap_or(&String::new()).clone();
-    let howpublished = fields.get("howpublished").unwrap_or(&String::new()).clone();
-    let year = fields.get("year");
-    let month = fields.get("month");
-    out.push_str(&fmt_authors_ieee(authors.clone()));
-    out.push_str(", ");
-    out.push_str(&title);
-    out.push_str(", ");
-    out.push_str(&howpublished);
-    out.push(',');
-    out.push_str(&fmt_year_month(year, month));
-    out.push('.');
-    out
-}
-fn fmt_conference_ieee(authors: Vec<OwnedFullName>, fields: BTreeMap<String, String>) -> String {
-    let mut out = String::new();
-    let title = fields.get("title").unwrap_or(&String::new()).clone();
-    let book_title = fields.get("booktitle").unwrap_or(&String::new()).clone();
-    let publisher = fields.get("publisher").unwrap_or(&String::new()).clone();
-    let address = fields.get("address").unwrap_or(&String::new()).clone();
-    let organization = fields.get("organization").unwrap_or(&String::new()).clone();
-    let pages = fields.get("pages").unwrap_or(&String::new()).clone();
-    let year = fields.get("year");
-    let month = fields.get("month");
-    let editors_str = fields.get("editor").unwrap_or(&String::new()).clone();
-    let (_tail, edrs) = and_seperated_names(&editors_str).unwrap();
-    let editor_names: Vec<OwnedFullName> = edrs.into_iter().map(|n| n.into()).collect();
-    out.push_str(&fmt_authors_ieee(authors.clone()));
-    out.push_str(", ");
-    out.push_str(&fmt_title_ieee(title));
-    out.push_str(" in ");
-    out.push_str(&book_title);
-    out.push_str(", ");
-    out.push_str(&fmt_authors_ieee(editor_names.clone()));
-    out.push_str(", Ed., ");
-    out.push_str(&organization);
-    out.push_str(", ");
-    out.push_str(&address);
-    out.push_str(": ");
-    out.push_str(&publisher);
-    out.push(',');
-    out.push_str(&fmt_year_month(year, month));
-    out.push_str(", pp. ");
-    out.push_str(&pages);
-    out.push('.');
-    out
-}
-fn fmt_inbook_ieee(authors: Vec<OwnedFullName>, fields: BTreeMap<String, String>) -> String {
-    let mut out = String::new();
-    let title = fields.get("title").unwrap_or(&String::new()).clone();
-    let book_title = fields.get("booktitle").unwrap_or(&String::new()).clone();
-    let publisher = fields.get("publisher").unwrap_or(&String::new()).clone();
-    let address = fields.get("address").unwrap_or(&String::new()).clone();
-    let pages = fields.get("pages").unwrap_or(&String::new()).clone();
-    let year = fields.get("year").unwrap_or(&String::new()).clone();
-    out.push_str(&fmt_authors_ieee(authors.clone()));
-    out.push_str(", ");
-    out.push_str(&fmt_title_ieee(title));
-    out.push_str(" in ");
-    out.push_str(&book_title);
-    out.push_str(". ");
-    out.push_str(&address);
-    out.push_str(": ");
-    out.push_str(&publisher);
-    out.push_str(", ");
-    out.push_str(&year);
-    out.push_str(", pp. ");
-    out.push_str(&pages);
-    out.push('.');
-    out
-}
-fn fmt_incollection_ieee(
-    authors: Vec<OwnedFullName>,
-    mut fields: BTreeMap<String, String>,
-) -> String {
-    let mut out = String::new();
-    let title = fields.get("title").unwrap_or(&String::new()).clone();
-    let book_title = fields.get("booktitle").unwrap_or(&String::new()).clone();
-    let publisher = fields.get("publisher").unwrap_or(&String::new()).clone();
-    let address = fields.get("address").unwrap_or(&String::new()).clone();
-    let pages = fields.get("pages").unwrap_or(&String::new()).clone();
-    let year = fields.get("year").unwrap_or(&String::new()).clone();
-    out.push_str(&fmt_authors_ieee(authors.clone()));
-    out.push_str(", ");
-    out.push_str(&fmt_title_ieee(title));
-    out.push_str(" in ");
-    out.push_str(&book_title);
-    out.push_str(", ");
-    let editors_str = fields.entry("editor".to_string()).or_default();
-    let (_tail, edrs) = and_seperated_names(editors_str).unwrap();
-    let editor_names: Vec<OwnedFullName> = edrs.into_iter().map(|n| n.into()).collect();
-    out.push_str(&fmt_authors_ieee(editor_names.clone()));
-    out.push_str(", Eds., ");
-    out.push_str(&address);
-    out.push_str(": ");
-    out.push_str(&publisher);
-    out.push_str(", ");
-    out.push_str(&year);
-    out.push_str(", pp. ");
-    out.push_str(&pages);
-    out.push('.');
-    out
-}
-fn fmt_manual_ieee(authors: Vec<OwnedFullName>, fields: BTreeMap<String, String>) -> String {
-    let mut out = String::new();
-    let title = fields.get("title").unwrap_or(&String::new()).clone();
-    let organization = fields.get("organization").unwrap_or(&String::new()).clone();
-    let address = fields.get("address").unwrap_or(&String::new()).clone();
-    let year = fields.get("year").unwrap_or(&String::new()).clone();
-    out.push_str(&fmt_authors_ieee(authors.clone()));
-    out.push_str(", ");
-    out.push_str(&title);
-    out.push_str(", ");
-    out.push_str(&organization);
-    out.push_str(", ");
-    out.push_str(&address);
-    out.push_str(", ");
-    out.push_str(&year);
-    out.push('.');
-    out
-}
-fn fmt_inprocedings_ieee(authors: Vec<OwnedFullName>, fields: BTreeMap<String, String>) -> String {
-    let mut out = String::new();
-    let title = fields.get("title").unwrap_or(&String::new()).clone();
-    let book_title = fields.get("booktitle").unwrap_or(&String::new()).clone();
-    let series = fields.get("series").unwrap_or(&String::new()).clone();
-    let publisher = fields.get("publisher").unwrap_or(&String::new()).clone();
-    let address = fields.get("address").unwrap_or(&String::new()).clone();
-    let pages = fields.get("pages").unwrap_or(&String::new()).clone();
-    let year = fields.get("year").unwrap_or(&String::new()).clone();
-    out.push_str(&fmt_authors_ieee(authors.clone()));
-    out.push_str(", ");
-    out.push_str(&fmt_title_ieee(title));
-    out.push_str(" in ");
-    out.push_str(&book_title);
-    out.push_str(", ser. ");
-    out.push_str(&series);
-    out.push_str(", ");
-    out.push_str(&address);
-    out.push_str(": ");
-    out.push_str(&publisher);
-    out.push_str(", ");
-    out.push_str(&year);
-    out.push_str(", pp. ");
-    out.push_str(&pages);
-    out.push('.');
-
-    out
-}
-fn fmt_procedings_ieee(mut fields: BTreeMap<String, String>) -> String {
-    // J. K. Author, “Title of paper,” presented at the Abbreviated Name of Conf., City of Conf., Abbrev. State, Country, Month and day(s), year, Paper number
-    let mut out = String::new();
-    let editors_str = fields.entry("editor".to_string()).or_default();
-    let (_tail, edrs) = and_seperated_names(editors_str).unwrap();
-    let editor_names: Vec<OwnedFullName> = edrs.into_iter().map(|n| n.into()).collect();
-    let title = fields.get("title").unwrap_or(&String::new()).clone();
-    let volume = fields.get("volume").unwrap_or(&String::new()).clone();
-    let series = fields.get("series").unwrap_or(&String::new()).clone();
-    let address = fields.get("address").unwrap_or(&String::new()).clone();
-    let publisher = fields.get("publisher").unwrap_or(&String::new()).clone();
-    let year = fields.get("year").unwrap_or(&String::new()).clone();
-    out.push_str(&fmt_authors_ieee(editor_names.clone()));
-    out.push_str(", Eds., ");
-    out.push_str(&title);
-    out.push_str(&format!(", vol. {}, ", volume));
-    out.push_str(&series);
-    out.push_str(", ");
-    out.push_str(&address);
-    out.push_str(": ");
-    out.push_str(&publisher);
-    out.push_str(", ");
-    out.push_str(&year);
-
-    out
-}
-fn fmt_unpublished_ieee(authors: Vec<OwnedFullName>, fields: BTreeMap<String, String>) -> String {
-    let mut out = String::new();
-    let title = fields.get("title").unwrap_or(&String::new()).clone();
-    out.push_str(&fmt_authors_ieee(authors.clone()));
-    out.push_str(", ");
-    out.push_str(&fmt_title_ieee(title));
-    out.push_str(" unpublished.");
-
-    out
-}
-fn fmt_tech_report_ieee(authors: Vec<OwnedFullName>, fields: BTreeMap<String, String>) -> String {
-    let title = fields.get("title").unwrap_or(&String::new()).clone();
-    let institution = fields.get("institution").unwrap_or(&String::new()).clone();
-    let address = fields.get("address").unwrap_or(&String::new()).clone();
-
-    let number = fields.get("number").unwrap_or(&String::new()).clone();
-    let year = fields.get("year");
-    let month = fields.get("month");
-    let mut out = String::new();
-    out.push_str(&fmt_authors_ieee(authors.clone()));
-    out.push_str(", ");
-    out.push_str(&fmt_title_ieee(title));
-    out.push(' ');
-    out.push_str(&institution);
-    out.push_str(", ");
-    out.push_str(&address);
-    out.push_str(", Tech. Rep. ");
-    out.push_str(&number);
-    out.push(',');
-    out.push_str(&fmt_year_month(year, month));
-    out.push('.');
-
-    out
-}
-
-fn fmt_year_month(year: Option<&String>, month: Option<&String>) -> String {
-    let mut out = String::new();
-    match (year, month) {
-        (None, None) => (),
-        (None, Some(_)) => (),
-
-        (Some(y), None) => {
-            out.push(' ');
-            out.push_str(y);
-        }
-        (Some(y), Some(m)) => {
-            out.push(' ');
-            // years generally don't get represented as anything other than number so unwrapping here is fine
-            let y_parsed = y.parse::<i32>().unwrap();
-            let m_parsed = m.parse::<u32>();
-            let date_formatted = match m_parsed {
-                Ok(m) => {
-                    let date = NaiveDate::from_ymd_opt(y_parsed, m, 1).unwrap();
-                    date.format("%b").to_string()
-                }
-                // if it's not a number just capitalise the first letter
-                Err(_) => m[0..1].to_uppercase() + &m[1..],
-            };
-            out.push_str(&date_formatted);
-            out.push_str(". ");
-            out.push_str(y);
-        }
-    };
-
-    out
-}
-
-fn fmt_article_ieee(authors: Vec<OwnedFullName>, fields: BTreeMap<String, String>) -> String {
-    let title = fields.get("title").unwrap_or(&String::new()).clone();
-    let volume = fields.get("volume").unwrap_or(&String::new()).clone();
-    let pages = fields.get("pages");
-    let journal = fields.get("journal").unwrap_or(&String::new()).clone();
-    let number = fields.get("number").unwrap_or(&String::new()).clone();
-    let year = fields.get("year");
-    let month = fields.get("month");
-    let doi = fields.get("doi");
-    let issn = fields.get("issn");
-    let url = fields.get("url");
-    let mut out = String::new();
-    out.push_str(&fmt_authors_ieee(authors.clone()));
-    out.push_str(", ");
-    out.push_str(&fmt_title_ieee(title));
-    out.push(' ');
-    out.push_str(&format!("{}, vol. {}, no. {}", journal, &volume, &number));
-    out.push(',');
-    if let Some(p) = pages {
-        out.push_str(" pp. ");
-        out.push_str(p);
-        out.push(',');
-    }
-    out.push_str(&fmt_year_month(year, month));
-
-    if let Some(i) = issn {
-        out.push(',');
-        out.push_str(" issn: ");
-        out.push_str(i);
-    };
-
-    if let Some(d) = doi {
+impl<T: Formatter> Stylizer for IeeeStylizer<T> {
+    fn fmt_book(&self, authors: Vec<OwnedFullName>, fields: BTreeMap<String, String>) -> String {
+        let mut out = String::new();
+        let mut title = fields.get("title").unwrap_or(&String::new()).clone();
+        let publisher = fields.get("publisher").unwrap_or(&String::new()).clone();
+        let address = fields.get("address").unwrap_or(&String::new()).clone();
+        let year = fields.get("year").unwrap_or(&String::new()).clone();
+        out.push_str(&self.fmt_authors(authors.clone()));
+        out.push_str(", ");
+        self.fmt.italics(&mut title);
+        out.push_str(&title);
+        out.push_str(". ");
+        out.push_str(&address);
+        out.push_str(": ");
+        out.push_str(&publisher);
+        out.push_str(", ");
+        out.push_str(&year);
         out.push('.');
-        out.push_str(" doi: ");
-        out.push_str(d);
-        out.push('.');
-    };
-
-    if let Some(u) = url {
-        out.push_str(" [Online]. Available: ");
-        out.push_str(u);
-        out.push('.');
-    };
-
-    if url.is_none() && doi.is_none() && issn.is_none() {
-        out.push('.')
+        out
     }
-
-    out
-}
-
-fn fmt_thesis_ieee(
-    theis_kind: ThesisKind,
-    authors: Vec<OwnedFullName>,
-    fields: BTreeMap<String, String>,
-) -> String {
-    let title = fields.get("title").unwrap_or(&String::new()).clone();
-    let year = fields.get("year");
-    let month = fields.get("month");
-    let school = fields.get("school");
-    let address = fields.get("address");
-    let mut out = String::new();
-    out.push_str(&fmt_authors_ieee(authors.clone()));
-    out.push_str(", ");
-    out.push_str(&fmt_title_ieee(title));
-    out.push(' ');
-    out.push_str(match theis_kind {
-        ThesisKind::Phd => "Ph.D. dissertation, ",
-        ThesisKind::Msc => "M.S. thesis, ",
-    });
-    if let Some(s) = school {
-        out.push_str(s);
+    fn fmt_booklet(&self, authors: Vec<OwnedFullName>, fields: BTreeMap<String, String>) -> String {
+        let mut out = String::new();
+        let title = fields.get("title").unwrap_or(&String::new()).clone();
+        let howpublished = fields.get("howpublished").unwrap_or(&String::new()).clone();
+        let year = fields.get("year");
+        let month = fields.get("month");
+        out.push_str(&self.fmt_authors(authors.clone()));
+        out.push_str(", ");
+        out.push_str(&title);
+        out.push_str(", ");
+        out.push_str(&howpublished);
         out.push(',');
+        out.push_str(&self.fmt_year_month(year, month));
+        out.push('.');
+        out
     }
-    if let Some(a) = address {
+    fn fmt_conference(
+        &self,
+        authors: Vec<OwnedFullName>,
+        fields: BTreeMap<String, String>,
+    ) -> String {
+        let mut out = String::new();
+        let title = fields.get("title").unwrap_or(&String::new()).clone();
+        let book_title = fields.get("booktitle").unwrap_or(&String::new()).clone();
+        let publisher = fields.get("publisher").unwrap_or(&String::new()).clone();
+        let address = fields.get("address").unwrap_or(&String::new()).clone();
+        let organization = fields.get("organization").unwrap_or(&String::new()).clone();
+        let pages = fields.get("pages").unwrap_or(&String::new()).clone();
+        let year = fields.get("year");
+        let month = fields.get("month");
+        let editors_str = fields.get("editor").unwrap_or(&String::new()).clone();
+        let (_tail, edrs) = and_seperated_names(&editors_str).unwrap();
+        let editor_names: Vec<OwnedFullName> = edrs.into_iter().map(|n| n.into()).collect();
+        out.push_str(&self.fmt_authors(authors.clone()));
+        out.push_str(", ");
+        out.push_str(&fmt_title(title));
+        out.push_str(" in ");
+        out.push_str(&book_title);
+        out.push_str(", ");
+        out.push_str(&self.fmt_authors(editor_names.clone()));
+        out.push_str(", Ed., ");
+        out.push_str(&organization);
+        out.push_str(", ");
+        out.push_str(&address);
+        out.push_str(": ");
+        out.push_str(&publisher);
+        out.push(',');
+        out.push_str(&self.fmt_year_month(year, month));
+        out.push_str(", pp. ");
+        out.push_str(&pages);
+        out.push('.');
+        out
+    }
+    fn fmt_inbook(&self, authors: Vec<OwnedFullName>, fields: BTreeMap<String, String>) -> String {
+        let mut out = String::new();
+        let title = fields.get("title").unwrap_or(&String::new()).clone();
+        let book_title = fields.get("booktitle").unwrap_or(&String::new()).clone();
+        let publisher = fields.get("publisher").unwrap_or(&String::new()).clone();
+        let address = fields.get("address").unwrap_or(&String::new()).clone();
+        let pages = fields.get("pages").unwrap_or(&String::new()).clone();
+        let year = fields.get("year").unwrap_or(&String::new()).clone();
+        out.push_str(&self.fmt_authors(authors.clone()));
+        out.push_str(", ");
+        out.push_str(&fmt_title(title));
+        out.push_str(" in ");
+        out.push_str(&book_title);
+        out.push_str(". ");
+        out.push_str(&address);
+        out.push_str(": ");
+        out.push_str(&publisher);
+        out.push_str(", ");
+        out.push_str(&year);
+        out.push_str(", pp. ");
+        out.push_str(&pages);
+        out.push('.');
+        out
+    }
+    fn fmt_incollection(
+        &self,
+        authors: Vec<OwnedFullName>,
+        mut fields: BTreeMap<String, String>,
+    ) -> String {
+        let mut out = String::new();
+        let title = fields.get("title").unwrap_or(&String::new()).clone();
+        let book_title = fields.get("booktitle").unwrap_or(&String::new()).clone();
+        let publisher = fields.get("publisher").unwrap_or(&String::new()).clone();
+        let address = fields.get("address").unwrap_or(&String::new()).clone();
+        let pages = fields.get("pages").unwrap_or(&String::new()).clone();
+        let year = fields.get("year").unwrap_or(&String::new()).clone();
+        out.push_str(&self.fmt_authors(authors.clone()));
+        out.push_str(", ");
+        out.push_str(&fmt_title(title));
+        out.push_str(" in ");
+        out.push_str(&book_title);
+        out.push_str(", ");
+        let editors_str = fields.entry("editor".to_string()).or_default();
+        let (_tail, edrs) = and_seperated_names(editors_str).unwrap();
+        let editor_names: Vec<OwnedFullName> = edrs.into_iter().map(|n| n.into()).collect();
+        out.push_str(&self.fmt_authors(editor_names.clone()));
+        out.push_str(", Eds., ");
+        out.push_str(&address);
+        out.push_str(": ");
+        out.push_str(&publisher);
+        out.push_str(", ");
+        out.push_str(&year);
+        out.push_str(", pp. ");
+        out.push_str(&pages);
+        out.push('.');
+        out
+    }
+    fn fmt_manual(&self, authors: Vec<OwnedFullName>, fields: BTreeMap<String, String>) -> String {
+        let mut out = String::new();
+        let title = fields.get("title").unwrap_or(&String::new()).clone();
+        let organization = fields.get("organization").unwrap_or(&String::new()).clone();
+        let address = fields.get("address").unwrap_or(&String::new()).clone();
+        let year = fields.get("year").unwrap_or(&String::new()).clone();
+        out.push_str(&self.fmt_authors(authors.clone()));
+        out.push_str(", ");
+        out.push_str(&title);
+        out.push_str(", ");
+        out.push_str(&organization);
+        out.push_str(", ");
+        out.push_str(&address);
+        out.push_str(", ");
+        out.push_str(&year);
+        out.push('.');
+        out
+    }
+    fn fmt_inproceedings(
+        &self,
+        authors: Vec<OwnedFullName>,
+        fields: BTreeMap<String, String>,
+    ) -> String {
+        let mut out = String::new();
+        let title = fields.get("title").unwrap_or(&String::new()).clone();
+        let book_title = fields.get("booktitle").unwrap_or(&String::new()).clone();
+        let series = fields.get("series").unwrap_or(&String::new()).clone();
+        let publisher = fields.get("publisher").unwrap_or(&String::new()).clone();
+        let address = fields.get("address").unwrap_or(&String::new()).clone();
+        let pages = fields.get("pages").unwrap_or(&String::new()).clone();
+        let year = fields.get("year").unwrap_or(&String::new()).clone();
+        out.push_str(&self.fmt_authors(authors.clone()));
+        out.push_str(", ");
+        out.push_str(&fmt_title(title));
+        out.push_str(" in ");
+        out.push_str(&book_title);
+        out.push_str(", ser. ");
+        out.push_str(&series);
+        out.push_str(", ");
+        out.push_str(&address);
+        out.push_str(": ");
+        out.push_str(&publisher);
+        out.push_str(", ");
+        out.push_str(&year);
+        out.push_str(", pp. ");
+        out.push_str(&pages);
+        out.push('.');
+
+        out
+    }
+    fn fmt_proceedings(&self, mut fields: BTreeMap<String, String>) -> String {
+        // J. K. Author, “Title of paper,” presented at the Abbreviated Name of Conf., City of Conf., Abbrev. State, Country, Month and day(s), year, Paper number
+        let mut out = String::new();
+        let editors_str = fields.entry("editor".to_string()).or_default();
+        let (_tail, edrs) = and_seperated_names(editors_str).unwrap();
+        let editor_names: Vec<OwnedFullName> = edrs.into_iter().map(|n| n.into()).collect();
+        let title = fields.get("title").unwrap_or(&String::new()).clone();
+        let volume = fields.get("volume").unwrap_or(&String::new()).clone();
+        let series = fields.get("series").unwrap_or(&String::new()).clone();
+        let address = fields.get("address").unwrap_or(&String::new()).clone();
+        let publisher = fields.get("publisher").unwrap_or(&String::new()).clone();
+        let year = fields.get("year").unwrap_or(&String::new()).clone();
+        out.push_str(&self.fmt_authors(editor_names.clone()));
+        out.push_str(", Eds., ");
+        out.push_str(&title);
+        out.push_str(&format!(", vol. {}, ", volume));
+        out.push_str(&series);
+        out.push_str(", ");
+        out.push_str(&address);
+        out.push_str(": ");
+        out.push_str(&publisher);
+        out.push_str(", ");
+        out.push_str(&year);
+
+        out
+    }
+    fn fmt_unpublished(
+        &self,
+        authors: Vec<OwnedFullName>,
+        fields: BTreeMap<String, String>,
+    ) -> String {
+        let mut out = String::new();
+        let title = fields.get("title").unwrap_or(&String::new()).clone();
+        out.push_str(&self.fmt_authors(authors.clone()));
+        out.push_str(", ");
+        out.push_str(&fmt_title(title));
+        out.push_str(" unpublished.");
+
+        out
+    }
+    fn fmt_techreport(
+        &self,
+        authors: Vec<OwnedFullName>,
+        fields: BTreeMap<String, String>,
+    ) -> String {
+        let title = fields.get("title").unwrap_or(&String::new()).clone();
+        let institution = fields.get("institution").unwrap_or(&String::new()).clone();
+        let address = fields.get("address").unwrap_or(&String::new()).clone();
+
+        let number = fields.get("number").unwrap_or(&String::new()).clone();
+        let year = fields.get("year");
+        let month = fields.get("month");
+        let mut out = String::new();
+        out.push_str(&self.fmt_authors(authors.clone()));
+        out.push_str(", ");
+        out.push_str(&fmt_title(title));
         out.push(' ');
-        out.push_str(a);
+        out.push_str(&institution);
+        out.push_str(", ");
+        out.push_str(&address);
+        out.push_str(", Tech. Rep. ");
+        out.push_str(&number);
         out.push(',');
-    }
-    out.push_str(&fmt_year_month(year, month));
-    out.push('.');
-
-    out
-}
-
-fn fmt_misc_ieee(authors: Vec<OwnedFullName>, fields: BTreeMap<String, String>) -> String {
-    let title = fields.get("title").unwrap_or(&String::new()).clone();
-    let year = fields.get("year");
-    let howpublished = fields.get("howpublished");
-    let note = fields.get("note");
-    let mut out = String::new();
-    out.push_str(&fmt_authors_ieee(authors.clone()));
-    out.push_str(", ");
-    out.push_str(&title);
-
-    if let Some(u) = howpublished {
-        out.push_str(", ");
-        out.push_str(u);
-    };
-    if let Some(n) = note {
-        out.push_str(", ");
-        out.push_str(n);
-    };
-    if let Some(y) = year {
-        out.push_str(", ");
-        out.push_str(y);
+        out.push_str(&self.fmt_year_month(year, month));
         out.push('.');
-    };
 
-    out
+        out
+    }
+
+    fn fmt_thesis(
+        &self,
+        theis_kind: ThesisKind,
+        authors: Vec<OwnedFullName>,
+        fields: BTreeMap<String, String>,
+    ) -> String {
+        let title = fields.get("title").unwrap_or(&String::new()).clone();
+        let year = fields.get("year");
+        let month = fields.get("month");
+        let school = fields.get("school");
+        let address = fields.get("address");
+        let mut out = String::new();
+        out.push_str(&self.fmt_authors(authors.clone()));
+        out.push_str(", ");
+        out.push_str(&fmt_title(title));
+        out.push(' ');
+        out.push_str(match theis_kind {
+            ThesisKind::Phd => "Ph.D. dissertation, ",
+            ThesisKind::Msc => "M.S. thesis, ",
+        });
+        if let Some(s) = school {
+            out.push_str(s);
+            out.push(',');
+        }
+        if let Some(a) = address {
+            out.push(' ');
+            out.push_str(a);
+            out.push(',');
+        }
+        out.push_str(&self.fmt_year_month(year, month));
+        out.push('.');
+
+        out
+    }
+
+    fn fmt_misc(&self, authors: Vec<OwnedFullName>, fields: BTreeMap<String, String>) -> String {
+        let title = fields.get("title").unwrap_or(&String::new()).clone();
+        let year = fields.get("year");
+        let howpublished = fields.get("howpublished");
+        let note = fields.get("note");
+        let mut out = String::new();
+        out.push_str(&self.fmt_authors(authors.clone()));
+        out.push_str(", ");
+        out.push_str(&title);
+
+        if let Some(u) = howpublished {
+            out.push_str(", ");
+            out.push_str(u);
+        };
+        if let Some(n) = note {
+            out.push_str(", ");
+            out.push_str(n);
+        };
+        if let Some(y) = year {
+            out.push_str(", ");
+            out.push_str(y);
+            out.push('.');
+        };
+
+        out
+    }
+
+    fn fmt_article(&self, authors: Vec<OwnedFullName>, fields: BTreeMap<String, String>) -> String {
+        let title = fields.get("title").unwrap_or(&String::new()).clone();
+        let volume = fields.get("volume").unwrap_or(&String::new()).clone();
+        let pages = fields.get("pages");
+        let journal = fields.get("journal").unwrap_or(&String::new()).clone();
+        let number = fields.get("number").unwrap_or(&String::new()).clone();
+        let year = fields.get("year");
+        let month = fields.get("month");
+        let doi = fields.get("doi");
+        let issn = fields.get("issn");
+        let url = fields.get("url");
+        let mut out = String::new();
+        out.push_str(&self.fmt_authors(authors.clone()));
+        out.push_str(", ");
+        out.push_str(&fmt_title(title));
+        out.push(' ');
+        out.push_str(&format!("{}, vol. {}, no. {}", journal, &volume, &number));
+        out.push(',');
+        if let Some(p) = pages {
+            out.push_str(" pp. ");
+            out.push_str(p);
+            out.push(',');
+        }
+        out.push_str(&self.fmt_year_month(year, month));
+
+        if let Some(i) = issn {
+            out.push(',');
+            out.push_str(" issn: ");
+            out.push_str(i);
+        };
+
+        if let Some(d) = doi {
+            out.push('.');
+            out.push_str(" doi: ");
+            out.push_str(d);
+            out.push('.');
+        };
+
+        if let Some(u) = url {
+            out.push_str(" [Online]. Available: ");
+            out.push_str(u);
+            out.push('.');
+        };
+
+        if url.is_none() && doi.is_none() && issn.is_none() {
+            out.push('.')
+        }
+
+        out
+    }
+
+    fn fmt_year_month(&self, year: Option<&String>, month: Option<&String>) -> String {
+        let mut out = String::new();
+        match (year, month) {
+            (None, None) => (),
+            (None, Some(_)) => (),
+
+            (Some(y), None) => {
+                out.push(' ');
+                out.push_str(y);
+            }
+            (Some(y), Some(m)) => {
+                out.push(' ');
+                // years generally don't get represented as anything other than number so unwrapping here is fine
+                let y_parsed = y.parse::<i32>().unwrap();
+                let m_parsed = m.parse::<u32>();
+                let date_formatted = match m_parsed {
+                    Ok(m) => {
+                        let date = NaiveDate::from_ymd_opt(y_parsed, m, 1).unwrap();
+                        date.format("%b").to_string()
+                    }
+                    // if it's not a number just capitalise the first letter
+                    Err(_) => m[0..1].to_uppercase() + &m[1..],
+                };
+                out.push_str(&date_formatted);
+                out.push_str(". ");
+                out.push_str(y);
+            }
+        };
+
+        out
+    }
+
+    fn fmt_authors(&self, authors: Vec<OwnedFullName>) -> String {
+        let mut authors = authors.clone();
+        match &authors.len() {
+            0 => String::new(),
+            1 => {
+                let author = authors.remove(0);
+                fmt_single_author(author)
+            }
+            2 => {
+                let author1 = authors.remove(0);
+                let author2 = authors.remove(0);
+                format!(
+                    "{} and {}",
+                    fmt_single_author(author1),
+                    fmt_single_author(author2)
+                )
+            }
+            3..=6 => {
+                let last_author = authors.remove(authors.len() - 1);
+                format!(
+                    "{}, and {}",
+                    authors
+                        .into_iter()
+                        .map(fmt_single_author)
+                        .collect::<Vec<String>>()
+                        .join(", "),
+                    fmt_single_author(last_author)
+                )
+            }
+            7.. => {
+                let first_three_authors = authors.drain(0..3);
+                format!(
+                    "{}, et al.",
+                    (first_three_authors
+                        .into_iter()
+                        .map(fmt_single_author)
+                        .collect::<Vec<String>>()
+                        .join(", "))
+                )
+            }
+        }
+    }
 }
 
-fn fmt_single_author_ieee(name: OwnedFullName) -> String {
+fn fmt_single_author(name: OwnedFullName) -> String {
     let mut out = String::new();
     if !name.first.is_empty() {
         out.push_str(
@@ -430,49 +473,7 @@ fn fmt_single_author_ieee(name: OwnedFullName) -> String {
     out
 }
 
-fn fmt_authors_ieee(mut authors: Vec<OwnedFullName>) -> String {
-    match &authors.len() {
-        0 => String::new(),
-        1 => {
-            let author = authors.remove(0);
-            fmt_single_author_ieee(author)
-        }
-        2 => {
-            let author1 = authors.remove(0);
-            let author2 = authors.remove(0);
-            format!(
-                "{} and {}",
-                fmt_single_author_ieee(author1),
-                fmt_single_author_ieee(author2)
-            )
-        }
-        3..=6 => {
-            let last_author = authors.remove(authors.len() - 1);
-            format!(
-                "{}, and {}",
-                authors
-                    .into_iter()
-                    .map(fmt_single_author_ieee)
-                    .collect::<Vec<String>>()
-                    .join(", "),
-                fmt_single_author_ieee(last_author)
-            )
-        }
-        7.. => {
-            let first_three_authors = authors.drain(0..3);
-            format!(
-                "{}, et al.",
-                (first_three_authors
-                    .into_iter()
-                    .map(fmt_single_author_ieee)
-                    .collect::<Vec<String>>()
-                    .join(", "))
-            )
-        }
-    }
-}
-
-fn fmt_title_ieee(title: String) -> String {
+fn fmt_title(title: String) -> String {
     format!("\"{},\"", title)
 }
 
@@ -480,7 +481,7 @@ fn fmt_title_ieee(title: String) -> String {
 mod test {
     use std::path::PathBuf;
 
-    use crate::parsing::bibligraphy::Bibliography;
+    use crate::{formaters::plain::PlainTextFormatter, parsing::bibligraphy::Bibliography};
 
     use super::*;
     use anyhow::Result;
@@ -491,7 +492,8 @@ mod test {
         let formatted_citation = "L. Breiman, \"Random forests,\" Machine learning, vol. 45, no. 1, pp. 5-32, 2001. doi: https://doi.org/10.1023/a:1010933404324.";
         let entries = Bibliography::from_file(PathBuf::from("cite.bib"))?;
         let entry = entries.get_entry(key.to_string()).unwrap();
-        let citation = fmt_reference_ieee(entry);
+        let stylizer = IeeeStylizer::<PlainTextFormatter>::default();
+        let citation = stylizer.fmt_reference(entry);
         assert_eq!(citation, formatted_citation);
         Ok(())
     }
@@ -501,7 +503,8 @@ mod test {
         let formatted_citation= "J. Liao, X. Cao, L. Zhao, et al., \"The importance of neutral and niche processes for bacterial community assembly differs between habitat generalists and specialists,\" FEMS Microbiology Ecology, vol. 92, no. 11, Aug. 2016, issn: 0168-6496. doi: https://doi.org/10.1093/femsec/fiw174. [Online]. Available: https://doi.org/10.1093/femsec/fiw174.";
         let entries = Bibliography::from_file(PathBuf::from("cite.bib"))?;
         let entry = entries.get_entry(key.to_string()).unwrap();
-        let citation = fmt_reference_ieee(entry);
+        let stylizer = IeeeStylizer::<PlainTextFormatter>::default();
+        let citation = stylizer.fmt_reference(entry);
         assert_eq!(citation, formatted_citation);
         Ok(())
     }
@@ -511,7 +514,8 @@ mod test {
         let formatted_citation= "P. J. Cohen, \"The independence of the continuum hypothesis,\" Proceedings of the National Academy of Sciences, vol. 50, no. 6, pp. 1143-1148, 1963.";
         let entries = Bibliography::from_file(PathBuf::from("cite.bib"))?;
         let entry = entries.get_entry(key.to_string()).unwrap();
-        let citation = fmt_reference_ieee(entry);
+        let stylizer = IeeeStylizer::<PlainTextFormatter>::default();
+        let citation = stylizer.fmt_reference(entry);
         assert_eq!(citation, formatted_citation);
         Ok(())
     }
@@ -521,7 +525,8 @@ mod test {
         let formatted_citation= "L. Susskind and G. Hrabovsky, Classical mechanics: the theoretical minimum. New York, NY: Penguin Random House, 2014.";
         let entries = Bibliography::from_file(PathBuf::from("cite.bib"))?;
         let entry = entries.get_entry(key.to_string()).unwrap();
-        let citation = fmt_reference_ieee(entry);
+        let stylizer = IeeeStylizer::<PlainTextFormatter>::default();
+        let citation = stylizer.fmt_reference(entry);
         assert_eq!(citation, formatted_citation);
         Ok(())
     }
@@ -531,7 +536,8 @@ mod test {
         let formatted_citation= "M. Swetla, Canoe tours in Sweden, Distributed at the Stockholm Tourist Office, Jul. 2015.";
         let entries = Bibliography::from_file(PathBuf::from("cite.bib"))?;
         let entry = entries.get_entry(key.to_string()).unwrap();
-        let citation = fmt_reference_ieee(entry);
+        let stylizer = IeeeStylizer::<PlainTextFormatter>::default();
+        let citation = stylizer.fmt_reference(entry);
         assert_eq!(citation, formatted_citation);
         Ok(())
     }
@@ -541,7 +547,8 @@ mod test {
         let formatted_citation= "L. A. Urry, M. L. Cain, S. A. Wasserman, P. V. Minorsky, and J. B. Reece, \"Photosynthesis,\" in Campbell biology. New York, NY: Pearson, 2016, pp. 187-221.";
         let entries = Bibliography::from_file(PathBuf::from("cite.bib"))?;
         let entry = entries.get_entry(key.to_string()).unwrap();
-        let citation = fmt_reference_ieee(entry);
+        let stylizer = IeeeStylizer::<PlainTextFormatter>::default();
+        let citation = stylizer.fmt_reference(entry);
         assert_eq!(citation, formatted_citation);
         Ok(())
     }
@@ -551,7 +558,8 @@ mod test {
         let formatted_citation= "H. M. Shapiro, \"Flow cytometry: The glass is half full,\" in Flow cytometry protocols, T. S. Hawley and R. G. Hawley, Eds., New York, NY: Springer, 2018, pp. 1-10.";
         let entries = Bibliography::from_file(PathBuf::from("cite.bib"))?;
         let entry = entries.get_entry(key.to_string()).unwrap();
-        let citation = fmt_reference_ieee(entry);
+        let stylizer = IeeeStylizer::<PlainTextFormatter>::default();
+        let citation = stylizer.fmt_reference(entry);
         assert_eq!(citation, formatted_citation);
         Ok(())
     }
@@ -561,7 +569,8 @@ mod test {
         let formatted_citation= "P. Holleis, M. Wagner, and J. Koolwaaij, \"Studying mobile context-aware social services in the wild,\" in Proc. of the 6th Nordic Conf. on Human-Computer Interaction, ser. NordiCHI, New York, NY: ACM, 2010, pp. 207-216.";
         let entries = Bibliography::from_file(PathBuf::from("cite.bib"))?;
         let entry = entries.get_entry(key.to_string()).unwrap();
-        let citation = fmt_reference_ieee(entry);
+        let stylizer = IeeeStylizer::<PlainTextFormatter>::default();
+        let citation = stylizer.fmt_reference(entry);
         assert_eq!(citation, formatted_citation);
         Ok(())
     }
@@ -571,7 +580,8 @@ mod test {
         let formatted_citation= "R Core Team, R: A language and environment for statistical computing, R Foundation for Statistical Computing, Vienna, Austria, 2018.";
         let entries = Bibliography::from_file(PathBuf::from("cite.bib"))?;
         let entry = entries.get_entry(key.to_string()).unwrap();
-        let citation = fmt_reference_ieee(entry);
+        let stylizer = IeeeStylizer::<PlainTextFormatter>::default();
+        let citation = stylizer.fmt_reference(entry);
         assert_eq!(citation, formatted_citation);
         Ok(())
     }
@@ -581,7 +591,8 @@ mod test {
         let formatted_citation= "J. Tang, \"Spin structure of the nucleon in the asymptotic limit,\" M.S. thesis, Massachusetts Institute of Technology, Cambridge, MA, Sep. 1996.";
         let entries = Bibliography::from_file(PathBuf::from("cite.bib"))?;
         let entry = entries.get_entry(key.to_string()).unwrap();
-        let citation = fmt_reference_ieee(entry);
+        let stylizer = IeeeStylizer::<PlainTextFormatter>::default();
+        let citation = stylizer.fmt_reference(entry);
         assert_eq!(citation, formatted_citation);
         Ok(())
     }
@@ -591,7 +602,8 @@ mod test {
         let formatted_citation= "NASA, Pluto: The 'other' red planet, https://www.nasa.gov/nh/pluto-the-other-red-planet, Accessed: 2018-12-06, 2015.";
         let entries = Bibliography::from_file(PathBuf::from("cite.bib"))?;
         let entry = entries.get_entry(key.to_string()).unwrap();
-        let citation = fmt_reference_ieee(entry);
+        let stylizer = IeeeStylizer::<PlainTextFormatter>::default();
+        let citation = stylizer.fmt_reference(entry);
         assert_eq!(citation, formatted_citation);
         Ok(())
     }
@@ -601,7 +613,8 @@ mod test {
         let formatted_citation= "R. C. Rempel, \"Relaxation effects for coupled nuclear spins,\" Ph.D. dissertation, Stanford University, Stanford, CA, Jun. 1956.";
         let entries = Bibliography::from_file(PathBuf::from("cite.bib"))?;
         let entry = entries.get_entry(key.to_string()).unwrap();
-        let citation = fmt_reference_ieee(entry);
+        let stylizer = IeeeStylizer::<PlainTextFormatter>::default();
+        let citation = stylizer.fmt_reference(entry);
         assert_eq!(citation, formatted_citation);
         Ok(())
     }
@@ -611,7 +624,8 @@ mod test {
         let formatted_citation= "S. Stepney and S. Verlan, Eds., Proceedings of the 17th international conference on computation and natural computation, fontainebleau, france, vol. 10867, Lecture Notes in Computer Science, Cham, Switzerland: Springer, 2018";
         let entries = Bibliography::from_file(PathBuf::from("cite.bib"))?;
         let entry = entries.get_entry(key.to_string()).unwrap();
-        let citation = fmt_reference_ieee(entry);
+        let stylizer = IeeeStylizer::<PlainTextFormatter>::default();
+        let citation = stylizer.fmt_reference(entry);
         assert_eq!(citation, formatted_citation);
         Ok(())
     }
@@ -621,7 +635,8 @@ mod test {
         let formatted_citation= "V. Bennett, K. Bowman, and S. Wright, \"Wasatch Solar Project final report,\" Salt Lake City Corporation, Salt Lake City, UT, Tech. Rep. DOE-SLC-6903-1, Sep. 2018.";
         let entries = Bibliography::from_file(PathBuf::from("cite.bib"))?;
         let entry = entries.get_entry(key.to_string()).unwrap();
-        let citation = fmt_reference_ieee(entry);
+        let stylizer = IeeeStylizer::<PlainTextFormatter>::default();
+        let citation = stylizer.fmt_reference(entry);
         assert_eq!(citation, formatted_citation);
         Ok(())
     }
@@ -631,7 +646,8 @@ mod test {
         let formatted_citation= "J. Smith and J. Doe, \"The Effects of Climate Change,\" in Proceedings of the Annual Conference on Climate Change, B. Johnson, Ed., Climate Change Association, Los Angeles, CA: Springer, Jun. 2022, pp. 55-62.";
         let entries = Bibliography::from_file(PathBuf::from("cite.bib"))?;
         let entry = entries.get_entry(key.to_string()).unwrap();
-        let citation = fmt_reference_ieee(entry);
+        let stylizer = IeeeStylizer::<PlainTextFormatter>::default();
+        let citation = stylizer.fmt_reference(entry);
         assert_eq!(citation, formatted_citation);
         Ok(())
     }
@@ -641,7 +657,8 @@ mod test {
         let formatted_citation = "M. Suresh, \"Evolution: A revised theory,\" unpublished.";
         let entries = Bibliography::from_file(PathBuf::from("cite.bib"))?;
         let entry = entries.get_entry(key.to_string()).unwrap();
-        let citation = fmt_reference_ieee(entry);
+        let stylizer = IeeeStylizer::<PlainTextFormatter>::default();
+        let citation = stylizer.fmt_reference(entry);
         assert_eq!(citation, formatted_citation);
         Ok(())
     }
@@ -653,7 +670,8 @@ mod test {
             von: vec![],
             title: vec![],
         };
-        let formated = fmt_authors_ieee(vec![author]);
+        let stylizer = IeeeStylizer::<PlainTextFormatter>::default();
+        let formated = stylizer.fmt_authors(vec![author]);
         assert_eq!(formated, "A. M. Lovelace Augusta");
 
         Ok(())
@@ -674,7 +692,8 @@ mod test {
                 title: vec![],
             },
         ];
-        let formated = fmt_authors_ieee(authors);
+        let stylizer = IeeeStylizer::<PlainTextFormatter>::default();
+        let formated = stylizer.fmt_authors(authors);
         assert_eq!(formated, "A. M. Lovelace Augusta and A. E. Noether");
 
         Ok(())
@@ -701,7 +720,8 @@ mod test {
                 title: vec![],
             },
         ];
-        let formated = fmt_authors_ieee(authors);
+        let stylizer = IeeeStylizer::<PlainTextFormatter>::default();
+        let formated = stylizer.fmt_authors(authors);
         assert_eq!(
             formated,
             "A. M. Lovelace Augusta, A. E. Noether, and S. Germain"
@@ -749,7 +769,8 @@ mod test {
                 title: vec![],
             },
         ];
-        let formated = fmt_authors_ieee(authors);
+        let stylizer = IeeeStylizer::<PlainTextFormatter>::default();
+        let formated = stylizer.fmt_authors(authors);
         assert_eq!(
             formated,
             "A. M. Lovelace Augusta, A. E. Noether, S. Germain, S. Kovalevskaya, D. Vaughn, and M. Mirzakhani"
@@ -815,7 +836,8 @@ mod test {
                 title: vec![],
             },
         ];
-        let formated = fmt_authors_ieee(authors);
+        let stylizer = IeeeStylizer::<PlainTextFormatter>::default();
+        let formated = stylizer.fmt_authors(authors);
         assert_eq!(
             formated,
             "A. M. Lovelace Augusta, A. E. Noether, S. Germain, et al."

--- a/src/styles/ieee.rs
+++ b/src/styles/ieee.rs
@@ -36,7 +36,8 @@ impl<T: Formatter> Stylizer for IeeeStylizer<T> {
     }
     fn fmt_booklet(&self, authors: Vec<OwnedFullName>, fields: BTreeMap<String, String>) -> String {
         let mut out = String::new();
-        let title = fields.get("title").unwrap_or(&String::new()).clone();
+        let mut title = fields.get("title").unwrap_or(&String::new()).clone();
+        self.fmt.italics(&mut title);
         let howpublished = fields.get("howpublished").unwrap_or(&String::new()).clone();
         let year = fields.get("year");
         let month = fields.get("month");
@@ -56,7 +57,8 @@ impl<T: Formatter> Stylizer for IeeeStylizer<T> {
         fields: BTreeMap<String, String>,
     ) -> String {
         let mut out = String::new();
-        let title = fields.get("title").unwrap_or(&String::new()).clone();
+        let mut title = fields.get("title").unwrap_or(&String::new()).clone();
+        self.fmt.italics(&mut title);
         let book_title = fields.get("booktitle").unwrap_or(&String::new()).clone();
         let publisher = fields.get("publisher").unwrap_or(&String::new()).clone();
         let address = fields.get("address").unwrap_or(&String::new()).clone();
@@ -146,7 +148,8 @@ impl<T: Formatter> Stylizer for IeeeStylizer<T> {
     }
     fn fmt_manual(&self, authors: Vec<OwnedFullName>, fields: BTreeMap<String, String>) -> String {
         let mut out = String::new();
-        let title = fields.get("title").unwrap_or(&String::new()).clone();
+        let mut title = fields.get("title").unwrap_or(&String::new()).clone();
+        self.fmt.italics(&mut title);
         let organization = fields.get("organization").unwrap_or(&String::new()).clone();
         let address = fields.get("address").unwrap_or(&String::new()).clone();
         let year = fields.get("year").unwrap_or(&String::new()).clone();
@@ -481,7 +484,10 @@ fn fmt_title(title: String) -> String {
 mod test {
     use std::path::PathBuf;
 
-    use crate::{formaters::plain::PlainTextFormatter, parsing::bibligraphy::Bibliography};
+    use crate::{
+        formaters::{html::HtmlFormatter, plain::PlainTextFormatter},
+        parsing::bibligraphy::Bibliography,
+    };
 
     use super::*;
     use anyhow::Result;
@@ -581,6 +587,17 @@ mod test {
         let entries = Bibliography::from_file(PathBuf::from("cite.bib"))?;
         let entry = entries.get_entry(key.to_string()).unwrap();
         let stylizer = IeeeStylizer::<PlainTextFormatter>::default();
+        let citation = stylizer.fmt_reference(entry);
+        assert_eq!(citation, formatted_citation);
+        Ok(())
+    }
+    #[test]
+    fn manual_formatted_citation_html() -> Result<()> {
+        let key = "manual";
+        let formatted_citation= "R Core Team, <i>R: A language and environment for statistical computing</i>, R Foundation for Statistical Computing, Vienna, Austria, 2018.";
+        let entries = Bibliography::from_file(PathBuf::from("cite.bib"))?;
+        let entry = entries.get_entry(key.to_string()).unwrap();
+        let stylizer = IeeeStylizer::<HtmlFormatter>::default();
         let citation = stylizer.fmt_reference(entry);
         assert_eq!(citation, formatted_citation);
         Ok(())

--- a/src/styles/mod.rs
+++ b/src/styles/mod.rs
@@ -1,6 +1,12 @@
-use self::apa::fmt_reference_apa;
-use crate::parsing::entry::BibEntry;
-use crate::styles::ieee::fmt_reference_ieee;
+use std::collections::BTreeMap;
+
+use apa::ApaStylizer;
+use ieee::fmt_reference_ieee;
+
+use crate::parsing::{
+    entry::{BibEntry, EntryType},
+    names::OwnedFullName,
+};
 
 pub mod apa;
 pub mod ieee;
@@ -12,7 +18,7 @@ pub enum ReferenceStyle {
     APA,
 }
 
-enum ThesisKind {
+pub enum ThesisKind {
     Phd,
     Msc,
 }
@@ -21,7 +27,50 @@ impl ReferenceStyle {
     pub fn fmt_reference(&self, entry: BibEntry) -> String {
         match self {
             ReferenceStyle::IEEE => fmt_reference_ieee(entry),
-            ReferenceStyle::APA => fmt_reference_apa(entry),
+            ReferenceStyle::APA => ApaStylizer::fmt_reference(entry),
+        }
+    }
+}
+pub trait Stylizer {
+    //required
+    fn fmt_unpublished(authors: Vec<OwnedFullName>, fields: BTreeMap<String, String>) -> String;
+    fn fmt_techreport(authors: Vec<OwnedFullName>, fields: BTreeMap<String, String>) -> String;
+    fn fmt_proceedings(fields: BTreeMap<String, String>) -> String;
+    fn fmt_thesis(
+        kind: ThesisKind,
+        authors: Vec<OwnedFullName>,
+        fields: BTreeMap<String, String>,
+    ) -> String;
+    fn fmt_misc(authors: Vec<OwnedFullName>, fields: BTreeMap<String, String>) -> String;
+    fn fmt_manual(authors: Vec<OwnedFullName>, fields: BTreeMap<String, String>) -> String;
+    fn fmt_inproceedings(authors: Vec<OwnedFullName>, fields: BTreeMap<String, String>) -> String;
+    fn fmt_incollection(authors: Vec<OwnedFullName>, fields: BTreeMap<String, String>) -> String;
+    fn fmt_inbook(authors: Vec<OwnedFullName>, fields: BTreeMap<String, String>) -> String;
+    fn fmt_conference(authors: Vec<OwnedFullName>, fields: BTreeMap<String, String>) -> String;
+    fn fmt_booklet(authors: Vec<OwnedFullName>, fields: BTreeMap<String, String>) -> String;
+    fn fmt_book(authors: Vec<OwnedFullName>, fields: BTreeMap<String, String>) -> String;
+    fn fmt_year_month(year: Option<&String>, month: Option<&String>, braces: bool) -> String;
+    fn fmt_article(authors: Vec<OwnedFullName>, fields: BTreeMap<String, String>) -> String;
+    fn fmt_authors(authors: Vec<OwnedFullName>) -> String;
+    // provided
+    fn fmt_reference(entry: BibEntry) -> String {
+        let (kind, _key, authors, fields) = entry.into_components();
+
+        match kind {
+            EntryType::Article => Self::fmt_article(authors, fields),
+            EntryType::Book => Self::fmt_book(authors, fields),
+            EntryType::Booklet => Self::fmt_booklet(authors, fields),
+            EntryType::Conference => Self::fmt_conference(authors, fields),
+            EntryType::Inbook => Self::fmt_inbook(authors, fields),
+            EntryType::Incollection => Self::fmt_incollection(authors, fields),
+            EntryType::Inproceedings => Self::fmt_inproceedings(authors, fields),
+            EntryType::Manual => Self::fmt_manual(authors, fields),
+            EntryType::Mastersthesis => Self::fmt_thesis(ThesisKind::Msc, authors, fields),
+            EntryType::Misc => Self::fmt_misc(authors, fields),
+            EntryType::Phdthesis => Self::fmt_thesis(ThesisKind::Phd, authors, fields),
+            EntryType::Proceedings => Self::fmt_proceedings(fields),
+            EntryType::Techreport => Self::fmt_techreport(authors, fields),
+            EntryType::Unpublished => Self::fmt_unpublished(authors, fields),
         }
     }
 }

--- a/src/styles/mod.rs
+++ b/src/styles/mod.rs
@@ -4,11 +4,12 @@ use apa::ApaStylizer;
 use ieee::IeeeStylizer;
 
 use crate::{
-    formaters::plain::PlainTextFormatter,
+    formaters::{html::HtmlFormatter, markdown::MarkdownFormatter, plain::PlainTextFormatter},
     parsing::{
         entry::{BibEntry, EntryType},
         names::OwnedFullName,
     },
+    Format,
 };
 
 pub mod apa;
@@ -27,13 +28,25 @@ pub enum ThesisKind {
 }
 
 impl ReferenceStyle {
-    pub fn fmt_reference(&self, entry: BibEntry) -> String {
-        match self {
-            ReferenceStyle::IEEE => {
+    pub fn fmt_reference(&self, entry: BibEntry, format: Format) -> String {
+        match (self, format) {
+            (ReferenceStyle::IEEE, Format::Plain) => {
                 IeeeStylizer::<PlainTextFormatter>::default().fmt_reference(entry)
             }
-            ReferenceStyle::APA => {
+            (ReferenceStyle::IEEE, Format::Html) => {
+                IeeeStylizer::<HtmlFormatter>::default().fmt_reference(entry)
+            }
+            (ReferenceStyle::IEEE, Format::Markdown) => {
+                IeeeStylizer::<MarkdownFormatter>::default().fmt_reference(entry)
+            }
+            (ReferenceStyle::APA, Format::Plain) => {
                 ApaStylizer::<PlainTextFormatter>::default().fmt_reference(entry)
+            }
+            (ReferenceStyle::APA, Format::Html) => {
+                ApaStylizer::<HtmlFormatter>::default().fmt_reference(entry)
+            }
+            (ReferenceStyle::APA, Format::Markdown) => {
+                ApaStylizer::<MarkdownFormatter>::default().fmt_reference(entry)
             }
         }
     }

--- a/src/styles/mod.rs
+++ b/src/styles/mod.rs
@@ -1,11 +1,14 @@
 use std::collections::BTreeMap;
 
 use apa::ApaStylizer;
-use ieee::fmt_reference_ieee;
+use ieee::IeeeStylizer;
 
-use crate::parsing::{
-    entry::{BibEntry, EntryType},
-    names::OwnedFullName,
+use crate::{
+    formaters::plain::PlainTextFormatter,
+    parsing::{
+        entry::{BibEntry, EntryType},
+        names::OwnedFullName,
+    },
 };
 
 pub mod apa;
@@ -26,51 +29,76 @@ pub enum ThesisKind {
 impl ReferenceStyle {
     pub fn fmt_reference(&self, entry: BibEntry) -> String {
         match self {
-            ReferenceStyle::IEEE => fmt_reference_ieee(entry),
-            ReferenceStyle::APA => ApaStylizer::fmt_reference(entry),
+            ReferenceStyle::IEEE => {
+                IeeeStylizer::<PlainTextFormatter>::default().fmt_reference(entry)
+            }
+            ReferenceStyle::APA => {
+                ApaStylizer::<PlainTextFormatter>::default().fmt_reference(entry)
+            }
         }
     }
 }
 pub trait Stylizer {
     //required
-    fn fmt_unpublished(authors: Vec<OwnedFullName>, fields: BTreeMap<String, String>) -> String;
-    fn fmt_techreport(authors: Vec<OwnedFullName>, fields: BTreeMap<String, String>) -> String;
-    fn fmt_proceedings(fields: BTreeMap<String, String>) -> String;
+    fn fmt_unpublished(
+        &self,
+        authors: Vec<OwnedFullName>,
+        fields: BTreeMap<String, String>,
+    ) -> String;
+    fn fmt_techreport(
+        &self,
+        authors: Vec<OwnedFullName>,
+        fields: BTreeMap<String, String>,
+    ) -> String;
+    fn fmt_proceedings(&self, fields: BTreeMap<String, String>) -> String;
     fn fmt_thesis(
+        &self,
         kind: ThesisKind,
         authors: Vec<OwnedFullName>,
         fields: BTreeMap<String, String>,
     ) -> String;
-    fn fmt_misc(authors: Vec<OwnedFullName>, fields: BTreeMap<String, String>) -> String;
-    fn fmt_manual(authors: Vec<OwnedFullName>, fields: BTreeMap<String, String>) -> String;
-    fn fmt_inproceedings(authors: Vec<OwnedFullName>, fields: BTreeMap<String, String>) -> String;
-    fn fmt_incollection(authors: Vec<OwnedFullName>, fields: BTreeMap<String, String>) -> String;
-    fn fmt_inbook(authors: Vec<OwnedFullName>, fields: BTreeMap<String, String>) -> String;
-    fn fmt_conference(authors: Vec<OwnedFullName>, fields: BTreeMap<String, String>) -> String;
-    fn fmt_booklet(authors: Vec<OwnedFullName>, fields: BTreeMap<String, String>) -> String;
-    fn fmt_book(authors: Vec<OwnedFullName>, fields: BTreeMap<String, String>) -> String;
-    fn fmt_year_month(year: Option<&String>, month: Option<&String>, braces: bool) -> String;
-    fn fmt_article(authors: Vec<OwnedFullName>, fields: BTreeMap<String, String>) -> String;
-    fn fmt_authors(authors: Vec<OwnedFullName>) -> String;
+    fn fmt_misc(&self, authors: Vec<OwnedFullName>, fields: BTreeMap<String, String>) -> String;
+    fn fmt_manual(&self, authors: Vec<OwnedFullName>, fields: BTreeMap<String, String>) -> String;
+    fn fmt_inproceedings(
+        &self,
+        authors: Vec<OwnedFullName>,
+        fields: BTreeMap<String, String>,
+    ) -> String;
+    fn fmt_incollection(
+        &self,
+        authors: Vec<OwnedFullName>,
+        fields: BTreeMap<String, String>,
+    ) -> String;
+    fn fmt_inbook(&self, authors: Vec<OwnedFullName>, fields: BTreeMap<String, String>) -> String;
+    fn fmt_conference(
+        &self,
+        authors: Vec<OwnedFullName>,
+        fields: BTreeMap<String, String>,
+    ) -> String;
+    fn fmt_booklet(&self, authors: Vec<OwnedFullName>, fields: BTreeMap<String, String>) -> String;
+    fn fmt_book(&self, authors: Vec<OwnedFullName>, fields: BTreeMap<String, String>) -> String;
+    fn fmt_article(&self, authors: Vec<OwnedFullName>, fields: BTreeMap<String, String>) -> String;
+    fn fmt_year_month(&self, year: Option<&String>, month: Option<&String>) -> String;
+    fn fmt_authors(&self, authors: Vec<OwnedFullName>) -> String;
     // provided
-    fn fmt_reference(entry: BibEntry) -> String {
+    fn fmt_reference(&self, entry: BibEntry) -> String {
         let (kind, _key, authors, fields) = entry.into_components();
 
         match kind {
-            EntryType::Article => Self::fmt_article(authors, fields),
-            EntryType::Book => Self::fmt_book(authors, fields),
-            EntryType::Booklet => Self::fmt_booklet(authors, fields),
-            EntryType::Conference => Self::fmt_conference(authors, fields),
-            EntryType::Inbook => Self::fmt_inbook(authors, fields),
-            EntryType::Incollection => Self::fmt_incollection(authors, fields),
-            EntryType::Inproceedings => Self::fmt_inproceedings(authors, fields),
-            EntryType::Manual => Self::fmt_manual(authors, fields),
-            EntryType::Mastersthesis => Self::fmt_thesis(ThesisKind::Msc, authors, fields),
-            EntryType::Misc => Self::fmt_misc(authors, fields),
-            EntryType::Phdthesis => Self::fmt_thesis(ThesisKind::Phd, authors, fields),
-            EntryType::Proceedings => Self::fmt_proceedings(fields),
-            EntryType::Techreport => Self::fmt_techreport(authors, fields),
-            EntryType::Unpublished => Self::fmt_unpublished(authors, fields),
+            EntryType::Article => Self::fmt_article(self, authors, fields),
+            EntryType::Book => Self::fmt_book(self, authors, fields),
+            EntryType::Booklet => Self::fmt_booklet(self, authors, fields),
+            EntryType::Conference => Self::fmt_conference(self, authors, fields),
+            EntryType::Inbook => Self::fmt_inbook(self, authors, fields),
+            EntryType::Incollection => Self::fmt_incollection(self, authors, fields),
+            EntryType::Inproceedings => Self::fmt_inproceedings(self, authors, fields),
+            EntryType::Manual => Self::fmt_manual(self, authors, fields),
+            EntryType::Mastersthesis => Self::fmt_thesis(self, ThesisKind::Msc, authors, fields),
+            EntryType::Misc => Self::fmt_misc(self, authors, fields),
+            EntryType::Phdthesis => Self::fmt_thesis(self, ThesisKind::Phd, authors, fields),
+            EntryType::Proceedings => Self::fmt_proceedings(self, fields),
+            EntryType::Techreport => Self::fmt_techreport(self, authors, fields),
+            EntryType::Unpublished => Self::fmt_unpublished(self, authors, fields),
         }
     }
 }

--- a/tests/bin_test.rs
+++ b/tests/bin_test.rs
@@ -86,6 +86,27 @@ fn run_unknown_key_and_book_ieee() {
     assert_eq!(str::from_utf8(&output.stdout), Ok(expected_output));
     assert_eq!(str::from_utf8(&output.stderr), Ok(expected_warning));
 }
+
+#[test]
+fn run_rf_ieee_html() {
+    let output = run_cmb()
+        .args([
+            "-b",
+            "cite.bib",
+            "--style",
+            "ieee",
+            "--format",
+            "html",
+            "10.1093/femsec/fiw174",
+        ])
+        .output()
+        .expect("could not run binary");
+    let expected_output = "J. Liao, X. Cao, L. Zhao, et al., \"The importance of neutral and niche processes for bacterial community assembly differs between habitat generalists and specialists,\" <i>FEMS Microbiology Ecology,</i> vol. 92, no. 11, Aug. 2016, issn: 0168-6496. doi: https://doi.org/10.1093/femsec/fiw174. [Online]. Available: <a href=\"https://doi.org/10.1093/femsec/fiw174\">https://doi.org/10.1093/femsec/fiw174</a>.\n";
+
+    dbg!(&output);
+    assert!(&output.status.success());
+    assert_eq!(str::from_utf8(&output.stdout), Ok(expected_output));
+}
 #[test]
 fn run_book_apa() {
     let output = run_cmb()

--- a/tests/bin_test.rs
+++ b/tests/bin_test.rs
@@ -107,6 +107,27 @@ fn run_rf_ieee_html() {
     assert!(&output.status.success());
     assert_eq!(str::from_utf8(&output.stdout), Ok(expected_output));
 }
+
+#[test]
+fn run_rf_apa_html() {
+    let output = run_cmb()
+        .args([
+            "-b",
+            "cite.bib",
+            "--style",
+            "apa",
+            "--format",
+            "html",
+            "10.1093/femsec/fiw174",
+        ])
+        .output()
+        .expect("could not run binary");
+    let expected_output = "Liao, J., Cao, X., Zhao, L., Wang, J., Gao, Z., Wang, M. C., & Huang, Y. (2016). The importance of neutral and niche processes for bacterial community assembly differs between habitat generalists and specialists. <i>FEMS Microbiology Ecology, 92</i> (11), <a href=\"https://doi.org/10.1093/femsec/fiw174\">https://doi.org/10.1093/femsec/fiw174</a>\n";
+
+    dbg!(&output);
+    assert!(&output.status.success());
+    assert_eq!(str::from_utf8(&output.stdout), Ok(expected_output));
+}
 #[test]
 fn run_book_apa() {
     let output = run_cmb()


### PR DESCRIPTION
Previously plaintext was the only way we did formatting which means that things like italics and hyperlinks were lost. This is fine if you're outputting over the terminal, but given that we'll want to integrate with things like `mdbook` it's good to have a bit more flexibility. It also means that we can adhere more closely to the citation rules wherever possible. 

The API might still need a bit of polish, but i don't want this PR to get too big, so we can iterate on that later. 